### PR TITLE
22 tc39 observables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ For TODO between alpha and release, see https://github.com/knockout/tko/issues/1
 * Expose `createViewModel` on Components registered with `Component.register`
 * Changed `Component.elementName` to `Component.customElementName` and use a kebab-case version of the class name for the custom element name by default
 * Pass `{element, templateNodes}` to the `Component` constructor as the second parameter of descendants of the `Component` class
+* Add support for `<ko binding='...'>`
+* Add basic support for `ko.subscribable` as TC39-Observables
 
 ## 🚚  Alpha-4a (8 Nov 2017)
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "prepublish": "yarn build",
     "test": "lerna exec --concurrency=1 --loglevel=warn -- yarn test",
+    "fast-test": "lerna exec --concurrency=6 --loglevel=warn -- yarn test",
     "build": "lerna exec --concurrency=1 --loglevel=warn -- yarn build",
     "lint": "standard",
     "repackage": "./tools/common-package-config.js packages/shared.package.json packages/*/package.json"

--- a/packages/tko.bind/src/LegacyBindingHandler.js
+++ b/packages/tko.bind/src/LegacyBindingHandler.js
@@ -26,6 +26,7 @@ export class LegacyBindingHandler extends BindingHandler {
   constructor (params) {
     super(params)
     const handler = this.handler
+    this.onError = params.onError
 
     if (typeof handler.dispose === 'function') {
       this.addDisposable(handler)
@@ -33,16 +34,18 @@ export class LegacyBindingHandler extends BindingHandler {
 
     try {
       this.initReturn = handler.init && handler.init(...this.legacyArgs)
-    } catch (e) { params.onError('init', e) }
+    } catch (e) {
+      params.onError('init', e)
+    }
+  }
 
-    if (typeof handler.update === 'function') {
-      this.computed(() => {
-        try {
-          handler.update(...this.legacyArgs)
-        } catch (e) {
-          params.onError('update', e)
-        }
-      })
+  onValueChange () {
+    const handler = this.handler
+    if (typeof handler.update !== 'function') { return }
+    try {
+      handler.update(...this.legacyArgs)
+    } catch (e) {
+      this.onError('update', e)
     }
   }
 

--- a/packages/tko.bind/src/applyBindings.js
+++ b/packages/tko.bind/src/applyBindings.js
@@ -284,6 +284,12 @@ function applyBindingsToNodeInternal (node, sourceBindings, bindingContext, asyn
           })
         )
 
+        if (bindingHandler.onValueChange) {
+          dependencyDetection.ignore(() =>
+            bindingHandler.computed('onValueChange')
+          )
+        }
+
         // Expose the bindings via domData.
         allBindingHandlers[key] = bindingHandler
 

--- a/packages/tko.binding.component/spec/componentBindingBehaviors.js
+++ b/packages/tko.binding.component/spec/componentBindingBehaviors.js
@@ -29,6 +29,10 @@ import {
 } from 'tko.binding.if'
 
 import {
+  NATIVE_BINDINGS
+} from 'tko.provider.native'
+
+import {
   bindings as componentBindings
 } from '../src'
 
@@ -944,6 +948,26 @@ describe('Components: Component binding', function () {
 
       children.unshift('rrr')
       expect(testNode.children[0].innerHTML).toEqual('<b>xrrrabc</b>')
+    })
+
+    it('gets params from the node', function () {
+      const x = {v: 'rrr'}
+      let seen = null
+      class ViewModel extends components.ComponentABC {
+        constructor (params) {
+          super(params)
+          seen = params
+        }
+
+        static get template () {
+          return { elementName: 'name', attributes: {}, children: [] }
+        }
+      }
+      ViewModel.register('test-component')
+      testNode.children[0][NATIVE_BINDINGS] = {x, y: () => x}
+      applyBindings(outerViewModel, testNode)
+      expect(seen.x).toEqual(x)
+      expect(seen.y()).toEqual(x)
     })
   })
 

--- a/packages/tko.binding.component/spec/componentBindingBehaviors.js
+++ b/packages/tko.binding.component/spec/componentBindingBehaviors.js
@@ -950,6 +950,21 @@ describe('Components: Component binding', function () {
       expect(testNode.children[0].innerHTML).toEqual('<b>xrrrabc</b>')
     })
 
+    it('inserts and updates observable template', function () {
+      const t = observable(["abc"])
+      class ViewModel extends components.ComponentABC {
+        get template () {
+          return t
+        }
+      }
+      ViewModel.register('test-component')
+      applyBindings(outerViewModel, testNode)
+      expect(testNode.children[0].innerHTML).toEqual('abc')
+
+      t(["rr", "vv"])
+      expect(testNode.children[0].innerHTML).toEqual('rrvv')
+    })
+
     it('gets params from the node', function () {
       const x = {v: 'rrr'}
       let seen = null

--- a/packages/tko.binding.component/src/componentBinding.js
+++ b/packages/tko.binding.component/src/componentBinding.js
@@ -11,7 +11,7 @@ import {
 } from 'tko.observable'
 
 import {
-  DescendantBindingHandler
+  DescendantBindingHandler, applyBindingsToDescendants
 } from 'tko.bind'
 
 import {
@@ -50,7 +50,10 @@ export default class ComponentBinding extends DescendantBindingHandler {
 
     if (maybeJsx(template)) {
       if (isObservable(template)) {
-        this.subscribe(template, jsx => this.setDomNodesFromJsx(jsx, element))
+        this.subscribe(template, jsx => {
+          this.setDomNodesFromJsx(jsx, element)
+          applyBindingsToDescendants(this.childBindingContext, this.$element)
+        })
       }
       this.setDomNodesFromJsx(unwrap(template), element)
     } else {
@@ -129,11 +132,11 @@ export default class ComponentBinding extends DescendantBindingHandler {
       $componentTemplateNodes: this.originalChildNodes
     })
 
-    const childBindingContext = this.$context.createChildContext(componentViewModel, /* dataItemAlias */ undefined, ctxExtender)
+    this.childBindingContext = this.$context.createChildContext(componentViewModel, /* dataItemAlias */ undefined, ctxExtender)
     this.currentViewModel = componentViewModel
 
     const onBinding = this.onBindingComplete.bind(this, componentViewModel)
-    const applied = this.applyBindingsToDescendants(childBindingContext, onBinding)
+    this.applyBindingsToDescendants(this.childBindingContext, onBinding)
   }
 
   onBindingComplete (componentViewModel, bindingResult) {

--- a/packages/tko.binding.component/src/componentBinding.js
+++ b/packages/tko.binding.component/src/componentBinding.js
@@ -18,6 +18,10 @@ import {
   jsxToNode, maybeJsx
 } from 'tko.utils.jsx'
 
+import {
+  NATIVE_BINDINGS
+} from 'tko.provider.native'
+
 import {LifeCycle} from 'tko.lifecycle'
 
 import registry from 'tko.utils.component'
@@ -47,8 +51,8 @@ export default class ComponentBinding extends DescendantBindingHandler {
     if (maybeJsx(template)) {
       if (isObservable(template)) {
         this.subscribe(template, jsx => this.setDomNodesFromJsx(jsx, element))
-        this.setDomNodesFromJsx(unwrap(template), element)
       }
+      this.setDomNodesFromJsx(unwrap(template), element)
     } else {
       const clonedNodesArray = cloneNodes(template)
       virtualElements.setDomNodeChildren(element, clonedNodesArray)
@@ -71,7 +75,8 @@ export default class ComponentBinding extends DescendantBindingHandler {
       componentName = value
     } else {
       componentName = unwrap(value.name)
-      componentParams = unwrap(value.params)
+      componentParams = NATIVE_BINDINGS in this.$element
+        ? this.$element[NATIVE_BINDINGS] : unwrap(value.params)
     }
 
     this.latestComponentName = componentName

--- a/packages/tko.binding.template/src/templating.js
+++ b/packages/tko.binding.template/src/templating.js
@@ -281,8 +281,6 @@ export class TemplateBindingHandler extends AsyncBindingHandler {
     } else {
       this.bindAnonymousTemplate()
     }
-
-    this.computed(this.onValueChange.bind(this))
   }
 
   bindNamedTemplate () {

--- a/packages/tko.computed/src/computed.js
+++ b/packages/tko.computed/src/computed.js
@@ -22,7 +22,8 @@ import {
     extenders,
     valuesArePrimitiveAndEqual,
     observable,
-    subscribable
+    subscribable,
+    LATEST_VALUE
 } from 'tko.observable'
 
 const computedState = createSymbolOrString('_state')
@@ -395,6 +396,10 @@ computed.fn = {
       this.evaluateImmediate()
     }
     return state.latestValue
+  },
+
+  get [LATEST_VALUE] () {
+    return this.peek()
   },
 
   limit (limitFunction) {

--- a/packages/tko.observable/spec/observableBehaviors.js
+++ b/packages/tko.observable/spec/observableBehaviors.js
@@ -348,7 +348,17 @@ describe('Observable', function () {
     expect(myObservable.customFunction1).toBe(customFunction1)
     expect(myObservable.customFunction2).toBe(customFunction2)
   })
+
+  it('immediately emits any value when called with {next: ...}', function () {
+    const instance = observable(1)
+    let x
+    instance.subscribe({next: v => (x = v)})
+    expect(x).toEqual(1)
+    observable(2)
+    expect(x).toEqual(1)
+  })
 })
+
 
 describe('unwrap', function () {
   it('Should return the supplied value for non-observables', function () {

--- a/packages/tko.observable/spec/subscribableBehaviors.js
+++ b/packages/tko.observable/spec/subscribableBehaviors.js
@@ -176,4 +176,12 @@ describe('Subscribable', function () {
     // Issue #2252: make sure .toString method does not throw error
     expect(new subscribable().toString()).toBe('[object Object]')
   })
+
+  it('subscribes with TC39 Observable {next: () =>}', function () {
+    var instance = new subscribable()
+    var notifiedValue
+    instance.subscribe({ next (value) { notifiedValue = value } })
+    instance.notifySubscribers(123)
+    expect(notifiedValue).toEqual(123)
+  })
 })

--- a/packages/tko.observable/src/Subscription.js
+++ b/packages/tko.observable/src/Subscription.js
@@ -1,0 +1,32 @@
+
+import {
+  removeDisposeCallback, addDisposeCallback
+} from 'tko.utils'
+
+
+export default class Subscription {
+  constructor (target, observer, disposeCallback) {
+    this._target = target
+    this._callback = observer.next
+    this._disposeCallback = disposeCallback
+    this._isDisposed = false
+    this._domNodeDisposalCallback = null
+  }
+
+  dispose () {
+    if (this._domNodeDisposalCallback) {
+      removeDisposeCallback(this._node, this._domNodeDisposalCallback)
+    }
+    this._isDisposed = true
+    this._disposeCallback()
+  }
+
+  disposeWhenNodeIsRemoved (node) {
+    this._node = node
+    addDisposeCallback(node, this._domNodeDisposalCallback = this.dispose.bind(this))
+  }
+
+  // TC39 Observable API
+  unsubscribe () { this.dispose() }
+  get closed () { return this._isDisposed }
+}

--- a/packages/tko.observable/src/index.js
+++ b/packages/tko.observable/src/index.js
@@ -9,7 +9,7 @@ export {
     observable, isObservable, unwrap, peek,
     isWriteableObservable, isWritableObservable
 } from './observable'
-export { isSubscribable, subscribable } from './subscribable'
+export { isSubscribable, subscribable, LATEST_VALUE } from './subscribable'
 export { observableArray, isObservableArray } from './observableArray'
 export { trackArrayChanges, arrayChangeEventName } from './observableArray.changeTracking'
 export { toJS, toJSON } from './mappingHelpers'

--- a/packages/tko.observable/src/observable.js
+++ b/packages/tko.observable/src/observable.js
@@ -58,9 +58,16 @@ observable.fn = {
   valueWillMutate () {
     this.notifySubscribers(this[observableLatestValue], 'beforeChange')
   },
-  // subscribe (callback, callbackTarget, event) {
+
+  // Note that TC39 `subscribe` ought to immediately emit.
   // https://github.com/tc39/proposal-observable/issues/190
-  // }
+  subscribe (callback, callbackTarget, event) {
+    const isTC39Callback = typeof callback === 'object' && callback.next
+    if (isTC39Callback) {
+      callback.next(this())
+    }
+    return subscribable.fn.subscribe.call(this, callback, callbackTarget, event)
+  },
 
   // Some observables may not always be writeable, notably computeds.
   isWriteable: true

--- a/packages/tko.observable/src/observable.js
+++ b/packages/tko.observable/src/observable.js
@@ -3,7 +3,7 @@
 //  ---
 //
 import {
-    createSymbolOrString, options, overwriteLengthPropertyIfSupported
+  options, overwriteLengthPropertyIfSupported
 } from 'tko.utils'
 
 import * as dependencyDetection from './dependencyDetection.js'
@@ -11,7 +11,7 @@ import { deferUpdates } from './defer.js'
 import { subscribable, defaultEvent } from './subscribable.js'
 import { valuesArePrimitiveAndEqual } from './extenders.js'
 
-var observableLatestValue = createSymbolOrString('_latestValue')
+var observableLatestValue = Symbol('_latestValue')
 
 export function observable (initialValue) {
   function Observable () {
@@ -58,6 +58,9 @@ observable.fn = {
   valueWillMutate () {
     this.notifySubscribers(this[observableLatestValue], 'beforeChange')
   },
+  // subscribe (callback, callbackTarget, event) {
+  // https://github.com/tc39/proposal-observable/issues/190
+  // }
 
   // Some observables may not always be writeable, notably computeds.
   isWriteable: true

--- a/packages/tko.observable/src/observable.js
+++ b/packages/tko.observable/src/observable.js
@@ -8,32 +8,30 @@ import {
 
 import * as dependencyDetection from './dependencyDetection.js'
 import { deferUpdates } from './defer.js'
-import { subscribable, defaultEvent } from './subscribable.js'
+import { subscribable, defaultEvent, LATEST_VALUE } from './subscribable.js'
 import { valuesArePrimitiveAndEqual } from './extenders.js'
-
-var observableLatestValue = Symbol('_latestValue')
 
 export function observable (initialValue) {
   function Observable () {
     if (arguments.length > 0) {
             // Write
             // Ignore writes if the value hasn't changed
-      if (Observable.isDifferent(Observable[observableLatestValue], arguments[0])) {
+      if (Observable.isDifferent(Observable[LATEST_VALUE], arguments[0])) {
         Observable.valueWillMutate()
-        Observable[observableLatestValue] = arguments[0]
+        Observable[LATEST_VALUE] = arguments[0]
         Observable.valueHasMutated()
       }
       return this // Permits chained assignments
     } else {
             // Read
       dependencyDetection.registerDependency(Observable) // The caller only needs to be notified of changes if they did a "read" operation
-      return Observable[observableLatestValue]
+      return Observable[LATEST_VALUE]
     }
   }
 
   overwriteLengthPropertyIfSupported(Observable, { value: undefined })
 
-  Observable[observableLatestValue] = initialValue
+  Observable[LATEST_VALUE] = initialValue
 
   subscribable.fn.init(Observable)
 
@@ -50,23 +48,13 @@ export function observable (initialValue) {
 // Define prototype for observables
 observable.fn = {
   equalityComparer: valuesArePrimitiveAndEqual,
-  peek () { return this[observableLatestValue] },
+  peek () { return this[LATEST_VALUE] },
   valueHasMutated () {
-    this.notifySubscribers(this[observableLatestValue], 'spectate')
-    this.notifySubscribers(this[observableLatestValue])
+    this.notifySubscribers(this[LATEST_VALUE], 'spectate')
+    this.notifySubscribers(this[LATEST_VALUE])
   },
   valueWillMutate () {
-    this.notifySubscribers(this[observableLatestValue], 'beforeChange')
-  },
-
-  // Note that TC39 `subscribe` ought to immediately emit.
-  // https://github.com/tc39/proposal-observable/issues/190
-  subscribe (callback, callbackTarget, event) {
-    const isTC39Callback = typeof callback === 'object' && callback.next
-    if (isTC39Callback) {
-      callback.next(this())
-    }
-    return subscribable.fn.subscribe.call(this, callback, callbackTarget, event)
+    this.notifySubscribers(this[LATEST_VALUE], 'beforeChange')
   },
 
   // Some observables may not always be writeable, notably computeds.

--- a/packages/tko.observable/src/subscribable.js
+++ b/packages/tko.observable/src/subscribable.js
@@ -1,37 +1,13 @@
 /* eslint no-cond-assign: 0 */
 import {
-    arrayRemoveItem, objectForEach, options, removeDisposeCallback,
-    addDisposeCallback
+    arrayRemoveItem, objectForEach, options
 } from 'tko.utils'
 
+import Subscription from './Subscription'
 import { SUBSCRIBABLE_SYM } from './subscribableSymbol'
-export { isSubscribable } from './subscribableSymbol'
 import { applyExtenders } from './extenders.js'
 import * as dependencyDetection from './dependencyDetection.js'
-
-
-export function subscription (target, callback, disposeCallback) {
-  this._target = target
-  this._callback = callback
-  this._disposeCallback = disposeCallback
-  this._isDisposed = false
-  this._domNodeDisposalCallback = null
-}
-
-Object.assign(subscription.prototype, {
-  dispose () {
-    if (this._domNodeDisposalCallback) {
-      removeDisposeCallback(this._node, this._domNodeDisposalCallback)
-    }
-    this._isDisposed = true
-    this._disposeCallback()
-  },
-
-  disposeWhenNodeIsRemoved (node) {
-    this._node = node
-    addDisposeCallback(node, this._domNodeDisposalCallback = this.dispose.bind(this))
-  }
-})
+export { isSubscribable } from './subscribableSymbol'
 
 export function subscribable () {
   Object.setPrototypeOf(this, ko_subscribable_fn)
@@ -42,6 +18,7 @@ export var defaultEvent = 'change'
 
 var ko_subscribable_fn = {
   [SUBSCRIBABLE_SYM]: true,
+  [Symbol.observable] () { return this },
 
   init (instance) {
     instance._subscriptions = { change: [] }
@@ -49,12 +26,16 @@ var ko_subscribable_fn = {
   },
 
   subscribe (callback, callbackTarget, event) {
-    var self = this
+    const self = this
+    // TC39 proposed standard Observable { next: () => ... }
+    const isTC39Callback = typeof callback === 'object' && callback.next
 
     event = event || defaultEvent
-    var boundCallback = callbackTarget ? callback.bind(callbackTarget) : callback
+    const observer = isTC39Callback ? callback : {
+      next: callbackTarget ? callback.bind(callbackTarget) : callback
+    }
 
-    var subscriptionInstance = new subscription(self, boundCallback, function () {
+    const subscriptionInstance = new Subscription(self, observer, function () {
       arrayRemoveItem(self._subscriptions[event], subscriptionInstance)
       if (self.afterSubscriptionRemove) {
         self.afterSubscriptionRemove(event)

--- a/packages/tko.provider.native/package.json
+++ b/packages/tko.provider.native/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "tko.provider.native",
+  "version": "4.0.0-alpha4",
+  "description": "Link binding handlers whose value is already attached to the node",
+  "module": "dist/tko.provider.native.js",
+  "files": [
+    "dist/"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "tko.provider": "^4.0.0-alpha4",
+    "tslib": "^1.8.0"
+  },
+  "karma": {
+    "frameworks": [
+      "mocha",
+      "chai"
+    ]
+  },
+  "__about__shared.package.json": "These properties are copied into all packages/*/package.json.  Run `yarn repackage`",
+  "standard": {
+    "globals": [
+      "assert",
+      "jasmine",
+      "beforeEach",
+      "before",
+      "after",
+      "afterEach",
+      "it",
+      "iit",
+      "xit",
+      "expect",
+      "describe",
+      "ddescribe"
+    ]
+  },
+  "scripts": {
+    "test": "karma start ../../karma.conf.js --once",
+    "build": "rollup -c ../../rollup.config.js",
+    "watch": "karma start ../../karma.conf.js"
+  }
+}

--- a/packages/tko.provider.native/spec/NativeProviderBehaviour.js
+++ b/packages/tko.provider.native/spec/NativeProviderBehaviour.js
@@ -10,13 +10,17 @@ describe('Native Provider Behaviour', function () {
     const attr = {'ko-thing': {}}
     div[NATIVE_BINDINGS] = attr
     assert.ok(p.nodeHasBindings(div), true)
-    assert.strictEqual(p.getBindingAccessors(div), attr)
+    const accessors = p.getBindingAccessors(div)
+    assert.equal(Object.keys(accessors).length, 1)
+    assert.strictEqual(accessors['thing'](), attr['ko-thing'])
   })
 
-  it('skips nodes w/o the symbol', function () {
+  it('ignores nodes w/o the symbol', function () {
     const p = new NativeProvider()
     const div = document.createElement('div')
-    assert.notOk(p.nodeHasBindings(div), true)
-    assert.equal(p.getBindingAccessors(div), undefined)
+    const attr = {'thing': {}}
+    div[NATIVE_BINDINGS] = attr
+    assert.notOk(p.nodeHasBindings(div), false)
+    assert.deepEqual(p.getBindingAccessors(div), {})
   })
 })

--- a/packages/tko.provider.native/spec/NativeProviderBehaviour.js
+++ b/packages/tko.provider.native/spec/NativeProviderBehaviour.js
@@ -1,0 +1,22 @@
+
+import {
+  NativeProvider, NATIVE_BINDINGS
+} from '../src'
+
+describe('Native Provider Behaviour', function () {
+  it('returns native bindings', function () {
+    const p = new NativeProvider()
+    const div = document.createElement('div')
+    const attr = {'ko-thing': {}}
+    div[NATIVE_BINDINGS] = attr
+    assert.ok(p.nodeHasBindings(div), true)
+    assert.strictEqual(p.getBindingAccessors(div), attr)
+  })
+
+  it('skips nodes w/o the symbol', function () {
+    const p = new NativeProvider()
+    const div = document.createElement('div')
+    assert.notOk(p.nodeHasBindings(div), true)
+    assert.equal(p.getBindingAccessors(div), undefined)
+  })
+})

--- a/packages/tko.provider.native/spec/NativeProviderBehaviour.js
+++ b/packages/tko.provider.native/spec/NativeProviderBehaviour.js
@@ -15,7 +15,7 @@ describe('Native Provider Behaviour', function () {
     assert.strictEqual(accessors['thing'](), attr['ko-thing'])
   })
 
-  it('ignores nodes w/o the symbol', function () {
+  it('has no bindings when no `ko-*` is present', function () {
     const p = new NativeProvider()
     const div = document.createElement('div')
     const attr = {'thing': {}}
@@ -23,4 +23,12 @@ describe('Native Provider Behaviour', function () {
     assert.notOk(p.nodeHasBindings(div), false)
     assert.deepEqual(p.getBindingAccessors(div), {})
   })
+
+  it('ignores nodes w/o the symbol', function () {
+    const p = new NativeProvider()
+    const div = document.createElement('div')
+    assert.notOk(p.nodeHasBindings(div), false)
+    assert.deepEqual(p.getBindingAccessors(div), {})
+  })
+
 })

--- a/packages/tko.provider.native/src/NativeProvider.js
+++ b/packages/tko.provider.native/src/NativeProvider.js
@@ -11,11 +11,11 @@ export const NATIVE_BINDINGS = Symbol('Knockout native bindings')
  *
  * Used by the jsxToNode function.
  */
-export default class JsxProvider extends Provider {
+export default class NativeProvider extends Provider {
   get FOR_NODE_TYPES () { return [ 1 ] } // document.ELEMENT_NODE
 
   nodeHasBindings (node) {
-    return Object.keys(node[NATIVE_BINDINGS])
+    return Object.keys(node[NATIVE_BINDINGS] || {})
       .some(key => key.startsWith('ko-'))
   }
 
@@ -25,7 +25,7 @@ export default class JsxProvider extends Provider {
    */
   getBindingAccessors (node) {
     return Object.assign({},
-      ...Object.entries(node[NATIVE_BINDINGS])
+      ...Object.entries(node[NATIVE_BINDINGS] || {})
         .filter(([name, value]) => name.startsWith('ko-'))
         .map(([name, value]) => ({[name.replace(/^ko-/, '')]: () => value}))
     )

--- a/packages/tko.provider.native/src/NativeProvider.js
+++ b/packages/tko.provider.native/src/NativeProvider.js
@@ -15,10 +15,19 @@ export default class JsxProvider extends Provider {
   get FOR_NODE_TYPES () { return [ 1 ] } // document.ELEMENT_NODE
 
   nodeHasBindings (node) {
-    return node[NATIVE_BINDINGS]
+    return Object.keys(node[NATIVE_BINDINGS])
+      .some(key => key.startsWith('ko-'))
   }
 
-  getBindingAccessors (node, context) {
-    return node[NATIVE_BINDINGS]
+  /**
+   * Return as valueAccessor function all the entries matching `ko-*`
+   * @param {HTMLElement} node
+   */
+  getBindingAccessors (node) {
+    return Object.assign({},
+      ...Object.entries(node[NATIVE_BINDINGS])
+        .filter(([name, value]) => name.startsWith('ko-'))
+        .map(([name, value]) => ({[name.replace(/^ko-/, '')]: () => value}))
+    )
   }
 }

--- a/packages/tko.provider.native/src/NativeProvider.js
+++ b/packages/tko.provider.native/src/NativeProvider.js
@@ -1,0 +1,24 @@
+
+import {
+  Provider
+} from 'tko.provider'
+
+export const NATIVE_BINDINGS = Symbol('Knockout native bindings')
+
+/**
+ * Retrieve the binding accessors that are already attached to
+ * a node under the `NATIVE_BINDINGS` symbol.
+ *
+ * Used by the jsxToNode function.
+ */
+export default class JsxProvider extends Provider {
+  get FOR_NODE_TYPES () { return [ 1 ] } // document.ELEMENT_NODE
+
+  nodeHasBindings (node) {
+    return node[NATIVE_BINDINGS]
+  }
+
+  getBindingAccessors (node, context) {
+    return node[NATIVE_BINDINGS]
+  }
+}

--- a/packages/tko.provider.native/src/index.js
+++ b/packages/tko.provider.native/src/index.js
@@ -1,0 +1,4 @@
+export {
+  default as NativeProvider,
+  NATIVE_BINDINGS
+} from './NativeProvider'

--- a/packages/tko.utils.jsx/src/jsx.js
+++ b/packages/tko.utils.jsx/src/jsx.js
@@ -71,6 +71,8 @@ function appendChildOrChildren (possibleTemplateElement, toAppend) {
  * @param {Node} beforeNode
  */
 function insertChildOrChildren (possibleTemplateElement, toAppend, beforeNode) {
+  if (!beforeNode.parentNode) { return }
+
   if (Array.isArray(toAppend)) {
     for (const node of toAppend) {
       appendChildOrChildren(possibleTemplateElement, node)
@@ -151,7 +153,15 @@ function replaceNodeOrNodes (newJsx, toReplace, parentNode) {
   } else {
     removeNode(toReplace)
   }
-  if ($context) { applyBindings($context, newNodeOrNodes) }
+  if ($context) {
+    if (Array.isArray(newNodeOrNodes)) {
+      for (const node of newNodeOrNodes) {
+        applyBindings($context, node)
+      }
+    } else {
+      applyBindings($context, newNodeOrNodes)
+    }
+  }
   return newNodeOrNodes
 }
 

--- a/packages/tko.utils.jsx/src/jsx.js
+++ b/packages/tko.utils.jsx/src/jsx.js
@@ -136,12 +136,9 @@ function updateChildren (node, children, subscriptions) {
  * @param {*} value
  */
 function setNodeAttribute (node, name, value) {
-  if (name.startsWith('ko-')) {
-    const nodeJsxAttrs = node[NATIVE_BINDINGS] || (node[NATIVE_BINDINGS] = {})
-    nodeJsxAttrs[name.replace(/^ko-/, '')] = () => value
-  } else {
-    node.setAttribute(name, value)
-  }
+  const nodeJsxAttrs = node[NATIVE_BINDINGS] || (node[NATIVE_BINDINGS] = {})
+  nodeJsxAttrs[name] = value
+  if (typeof value === 'string') { node.setAttribute(name, value) }
 }
 
 /**

--- a/packages/tko.utils.jsx/src/jsx.js
+++ b/packages/tko.utils.jsx/src/jsx.js
@@ -109,7 +109,7 @@ function insertChildOrChildren (possibleTemplateElement, toAppend, beforeNode) {
 
   if (Array.isArray(toAppend)) {
     for (const node of toAppend) {
-      appendChildOrChildren(possibleTemplateElement, node)
+      insertChildOrChildren(possibleTemplateElement, node, beforeNode)
     }
   } else {
     getInsertTarget(possibleTemplateElement).insertBefore(toAppend, beforeNode)

--- a/packages/tko/src/index.js
+++ b/packages/tko/src/index.js
@@ -8,6 +8,9 @@ import { MultiProvider } from 'tko.provider.multi'
 import {
   TextMustacheProvider, AttributeMustacheProvider
 } from 'tko.provider.mustache'
+import {
+  NativeProvider
+} from 'tko.provider.native'
 
 import { bindings as coreBindings } from 'tko.binding.core'
 import { bindings as templateBindings } from 'tko.binding.template'
@@ -28,7 +31,8 @@ const builder = new Builder({
       new ComponentProvider(),
       new DataBindProvider(),
       new VirtualProvider(),
-      new AttributeProvider()
+      new AttributeProvider(),
+      new NativeProvider()
     ]
   }),
   bindings: [


### PR DESCRIPTION
@mbest - You can see I've added in support for the TC39 `{next:...}` style of argument to `subscribe`. 

I use the argument-type (i.e. an object with a `next` method) to detect whether it's TC39-compliant call, in which case the current value of an observable is emitted immediately/synchronously.

It occurred to me that perhaps we want to have a different approach to this, such as adding a new event type (i.e. `state` instead of `change`).  Any thoughts?