### PR TITLE
functionRewrite improvements

### DIFF
--- a/packages/utils.functionrewrite/spec/functionRewriteBehavior.ts
+++ b/packages/utils.functionrewrite/spec/functionRewriteBehavior.ts
@@ -14,7 +14,8 @@ describe('Function Rewrite Provider', function () {
       'x: function () { return {} }': 'x: () => { }',
       'x: function () { return "abc" }': 'x: () => "abc"',
       'stringLiteral: "hello", numberLiteral: 123, boolLiteralTrue: true, boolLiteralFalse: false, objectLiteral: {}, functionLiteral: function() { }, nullLiteral: null, undefinedLiteral: undefined': 'stringLiteral: "hello", numberLiteral: 123, boolLiteralTrue: true, boolLiteralFalse: false, objectLiteral: {}, functionLiteral: () => undefined, nullLiteral: null, undefinedLiteral: undefined',
-      'function (v) { return v.name + " (" + v.job + ")"; }': '(v) => v.name + " (" + v.job + ")"'
+      'function (v) { return v.name + " (" + v.job + ")"; }': '(v) => v.name + " (" + v.job + ")"',
+      'function () { foo(); }': '() => foo() && undefined'
     }
     const idempotents = [
       'x: nonfunction () {}'

--- a/packages/utils.functionrewrite/spec/functionRewriteBehavior.ts
+++ b/packages/utils.functionrewrite/spec/functionRewriteBehavior.ts
@@ -14,7 +14,7 @@ describe('Function Rewrite Provider', function () {
       'x: function () { return {} }': 'x: () => { }',
       'x: function () { return "abc" }': 'x: () => "abc"',
       'stringLiteral: "hello", numberLiteral: 123, boolLiteralTrue: true, boolLiteralFalse: false, objectLiteral: {}, functionLiteral: function() { }, nullLiteral: null, undefinedLiteral: undefined': 'stringLiteral: "hello", numberLiteral: 123, boolLiteralTrue: true, boolLiteralFalse: false, objectLiteral: {}, functionLiteral: () => undefined, nullLiteral: null, undefinedLiteral: undefined',
-      'function (v) { return v.name + " (" + v.job + ")"; }': '(v) => v.name + " (" + v.job + ")";'
+      'function (v) { return v.name + " (" + v.job + ")"; }': '(v) => v.name + " (" + v.job + ")"'
     }
     const idempotents = [
       'x: nonfunction () {}'

--- a/packages/utils.functionrewrite/src/functionRewrite.ts
+++ b/packages/utils.functionrewrite/src/functionRewrite.ts
@@ -4,14 +4,18 @@
  *
  */
 
-const FUNCTION_REX = /\bfunction\s*\(([^)]*)\)\s*{\s*(?:(?:return\s+)?([^}]+?)[;\s]*)?}/g
+const FUNCTION_REX = /\bfunction\s*\(([^)]*)\)\s*{\s*(?:(return\s+)?([^}]+?)[;\s]*)?}/g
 
 export default function functionRewrite (bindingString) {
   return bindingString
-    .replace(FUNCTION_REX, (match, args, rv) => {
-      if (!functionRewrite.silent) {
-        console.log(`Knockout: Replace "${match}" with "(${args.trim()}) => ${rv}"`)
+    .replace(FUNCTION_REX, (match, args, returnKeyword, rv) => {
+      if (rv && !returnKeyword) {
+        rv += ' && undefined'
       }
-      return `(${args.trim()}) => ${rv}`
+      const out = `(${args.trim()}) => ${rv}`
+      if (!functionRewrite.silent) {
+        console.log(`Knockout: Replace "${match}" with "${out}"`)
+      }
+      return out
   })
 }

--- a/packages/utils.functionrewrite/src/functionRewrite.ts
+++ b/packages/utils.functionrewrite/src/functionRewrite.ts
@@ -4,7 +4,7 @@
  *
  */
 
-const FUNCTION_REX = /\bfunction\s*\(([^)]*)\)\s*{\s*(?:(return\s+)?([^}]+?)[;\s]*)?}/g
+const FUNCTION_REX = /\bfunction\s*\(([^)]*)\)\s*\{\s*(?:(return\s)?([^}]+?)[;\s]*)?\}/g
 
 export default function functionRewrite (bindingString) {
   return bindingString

--- a/packages/utils.functionrewrite/src/functionRewrite.ts
+++ b/packages/utils.functionrewrite/src/functionRewrite.ts
@@ -4,7 +4,7 @@
  *
  */
 
-const FUNCTION_REX = /\bfunction\s*\(([^)]*)\)\s*{\s*(?:return\s+([^}]+?)[;\s]*)?}/g
+const FUNCTION_REX = /\bfunction\s*\(([^)]*)\)\s*{\s*(?:(?:return\s+)?([^}]+?)[;\s]*)?}/g
 
 export default function functionRewrite (bindingString) {
   return bindingString

--- a/packages/utils.functionrewrite/src/functionRewrite.ts
+++ b/packages/utils.functionrewrite/src/functionRewrite.ts
@@ -4,7 +4,7 @@
  *
  */
 
-const FUNCTION_REX = /\bfunction\s*\(([^)]*)\)\s*{\s*(?:return\s+([^}]+?)\s*)?}/g
+const FUNCTION_REX = /\bfunction\s*\(([^)]*)\)\s*{\s*(?:return\s+([^}]+?)[;\s]*)?}/g
 
 export default function functionRewrite (bindingString) {
   return bindingString

--- a/packages/utils.functionrewrite/src/functionRewrite.ts
+++ b/packages/utils.functionrewrite/src/functionRewrite.ts
@@ -9,9 +9,9 @@ const FUNCTION_REX = /\bfunction\s*\(([^)]*)\)\s*{\s*(?:(?:return\s+)?([^}]+?)[;
 export default function functionRewrite (bindingString) {
   return bindingString
     .replace(FUNCTION_REX, (match, args, rv) => {
-    if (!functionRewrite.silent) {
-      console.log(`Knockout: Replace "${match}" with "=> ${rv}"`)
-    }
-    return `(${args.trim()}) => ${rv}`
+      if (!functionRewrite.silent) {
+        console.log(`Knockout: Replace "${match}" with "(${args.trim()}) => ${rv}"`)
+      }
+      return `(${args.trim()}) => ${rv}`
   })
 }

--- a/packages/utils.parser/src/Parser.ts
+++ b/packages/utils.parser/src/Parser.ts
@@ -656,7 +656,7 @@ export default class Parser {
       case 'null': return null
       case 'undefined': return void 0
       case 'function':
-        throw new Error('Knockout: Anonymous functions are no longer supported, but `=>` lambdas are.')
+        throw new Error('Knockout: Anonymous functions are no longer supported, but `=>` lambdas are. In: ' + this.text)
     // return this.anonymous_fn();
     }
     return new Identifier(this, token, this.dereferences())


### PR DESCRIPTION
* strip trailing semicolon from function body
* make `return` optional for side-effects-only functions
* log the args when rewriting
* include the binding text in error messages for any remaining deprecated `function` bindings so that these can be located more easily in the source