### PR TITLE
Use == for comparing select option values for better ko compatibility

### DIFF
--- a/packages/utils/spec/utilsDomBehaviors.ts
+++ b/packages/utils/spec/utilsDomBehaviors.ts
@@ -123,3 +123,21 @@ describe('cloneNodes', function () {
     expect(childIsClone).toBe(true)
   })
 })
+
+describe('selectExtensions', () => {
+  beforeEach(jasmine.prepareTestNode)
+
+  it('should use loose equality for select value', () => {
+    const select = document.createElement('select')
+    select.innerHTML = `
+      <option value="42" selected>Forty-two</option>
+      <option value="84">Eighty-four</option>
+    `
+    testNode.appendChild(select)
+
+    expect(select.selectedIndex).toBe(0)
+    expect(utils.selectExtensions.readValue(select)).toBe('42')
+    utils.selectExtensions.writeValue(select, 84, true)
+    expect(select.selectedIndex).toBe(1)
+  })
+})

--- a/packages/utils/src/dom/selectExtensions.ts
+++ b/packages/utils/src/dom/selectExtensions.ts
@@ -53,7 +53,8 @@ export var selectExtensions = {
         for (let i = 0, n = element.options.length, optionValue; i < n; ++i) {
           optionValue = selectExtensions.readValue(element.options[i])
           // Include special check to handle selecting a caption with a blank string value
-          if (optionValue === value || (optionValue === '' && value === undefined)) {
+          // Note that the looser == check here is intentional so that integer model values will match string element values.
+          if (optionValue == value || (optionValue === '' && value === undefined)) {
             selection = i
             break
           }


### PR DESCRIPTION
Knockout uses `==` for comparing select option values against the value binding value, and this PR restores that behavior for better compatibility. This is critical if you have bindings like this:
```html
<select data-bind="value: typeID">
  <option value="1">foo</option>
  <option value="2">bar</option>
  ...
```

I'll try to make a test for this if I have time.