### PR TITLE
Remove mustache providers from ko build for backwards compatibility

### DIFF
--- a/builds/knockout/package.json
+++ b/builds/knockout/package.json
@@ -58,7 +58,6 @@
     "@tko/provider.component": "^4.0.0-alpha9.0",
     "@tko/provider.databind": "^4.0.0-alpha9.0",
     "@tko/provider.multi": "^4.0.0-alpha8.4",
-    "@tko/provider.mustache": "^4.0.0-alpha9.0",
     "@tko/provider.virtual": "^4.0.0-alpha9.0",
     "@tko/utils.component": "^4.0.0-alpha9.0",
     "@tko/utils.functionrewrite": "^4.0.0-alpha8.2",

--- a/builds/knockout/src/index.js
+++ b/builds/knockout/src/index.js
@@ -5,9 +5,6 @@ import { DataBindProvider } from '@tko/provider.databind'
 import { ComponentProvider } from '@tko/provider.component'
 import { AttributeProvider } from '@tko/provider.attr'
 import { MultiProvider } from '@tko/provider.multi'
-import {
-  TextMustacheProvider, AttributeMustacheProvider
-} from '@tko/provider.mustache'
 
 import { bindings as coreBindings } from '@tko/binding.core'
 import { bindings as templateBindings } from '@tko/binding.template'
@@ -34,8 +31,6 @@ const builder = new Builder({
   filters,
   provider: new MultiProvider({
     providers: [
-      new AttributeMustacheProvider(),
-      new TextMustacheProvider(),
       new ComponentProvider(),
       dataBindProvider,
       new VirtualProvider(),


### PR DESCRIPTION
Because knockout didn’t have mustache/handlebar style interpolation, there can exist templates that contain arbitrary and unrelated `{{...}}` in text and attributes, which break under tko. In our case, we had some server-side rendered templates that injected (html-escaped) user-provided text, that would subsequently by bound with knockout, and on rare occasion the user-provided text included mustaches that would be parsed as bindings and fail.

For this reason, I propose leaving `TextMustacheProvider` and `AttributeMustacheProvider` out of the MultiProvider for the knockout compat build as in this PR.