### PR TITLE
Make options.bindingGlobals empty by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For TODO between alpha and release, see https://github.com/knockout/tko/issues/1
 - add `preventDefault` to event handler bindings
 - switch source to Typescript (but no types exported yet)
 - change build.reference & build.knockout build export strategy
+- make bindingGlobals empty by default (#165 @danieldickison)
 
 ## 👑 `alpha 9` (28 Feb 2020)
 

--- a/builds/knockout/spec/bindingGlobalsBehaviors.js
+++ b/builds/knockout/spec/bindingGlobalsBehaviors.js
@@ -1,0 +1,20 @@
+describe('options.bindingGlobals', function() {
+    beforeEach(jasmine.prepareTestNode);
+
+    it('references the global window by default', function() {
+        this.after(function () { ko.cleanNode(document.body); });     // Just to avoid interfering with other specs
+
+        window.testFoo = "bar";
+        testNode.innerHTML = "<div id='testFoo' data-bind='text: testFoo'></div>";
+        ko.applyBindings();
+        expect(document.getElementById("testFoo").innerText).toEqual("bar");
+    });
+
+    xit('is reassignable (https://github.com/knockout/tko/issues/166)', function() {
+        this.skip();
+        ko.options.bindingGlobals = {foo: "bar"};
+        testNode.innerHTML = "<div id='testFoo' data-bind='text: foo'></div>";
+        ko.applyBindings();
+        expect(document.getElementById("testFoo").innerText).toEqual("bar");
+    });
+});

--- a/builds/knockout/src/index.js
+++ b/builds/knockout/src/index.js
@@ -18,6 +18,8 @@ import components from '@tko/utils.component'
 
 import { functionRewrite } from '@tko/utils.functionrewrite'
 
+import { options as defaultOptions } from '@tko/utils'
+
 /**
  * expressionRewriting is deprecated in TKO because we have our own JS
  * parser now.  This is here only for legacy compatibility.
@@ -45,6 +47,7 @@ const builder = new Builder({
     { each: foreachBindings.foreach }
   ],
   options: {
+    bindingGlobals: defaultOptions.global,
     bindingStringPreparsers: [functionRewrite]
   }
 })

--- a/builds/reference/spec/bindingGlobalsBehavior.js
+++ b/builds/reference/spec/bindingGlobalsBehavior.js
@@ -1,0 +1,13 @@
+import tko from '..'
+
+describe('options.bindingGlobals', () => {
+  it('is not globalThis by default', () => {
+    expect(Object.getPrototypeOf(tko.options.bindingGlobals)).to.be.null
+
+    globalThis.testFoo = "bar"
+    expect(tko.options.bindingGlobals.testFoo).to.be.undefined
+
+    tko.options.bindingGlobals.testFoo = 1
+    expect(tko.options.bindingGlobals.testFoo).to.equal(1)
+  })
+})

--- a/packages/utils/src/options.ts
+++ b/packages/utils/src/options.ts
@@ -22,7 +22,7 @@ var options = {
   allowVirtualElements: true,
 
     // Global variables that can be accessed from bindings.
-  bindingGlobals: _global,
+  bindingGlobals: {},
 
     // An instance of the binding provider.
   bindingProviderInstance: null,

--- a/packages/utils/src/options.ts
+++ b/packages/utils/src/options.ts
@@ -22,7 +22,7 @@ var options = {
   allowVirtualElements: true,
 
     // Global variables that can be accessed from bindings.
-  bindingGlobals: {},
+  bindingGlobals: Object.create(null),
 
     // An instance of the binding provider.
   bindingProviderInstance: null,

--- a/packages/utils/src/options.ts
+++ b/packages/utils/src/options.ts
@@ -4,11 +4,7 @@
 //
 // This is the root 'options', which must be extended by others.
 
-var _global
-
-try { _global = window } catch (e) { _global = global }
-
-var options = {
+const options = {
   deferUpdates: false,
 
   useOnlyNativeEvents: false,
@@ -30,19 +26,19 @@ var options = {
   // Whether the `with` binding creates a child context when used with `as`.
   createChildContextWithAs: false,
 
-    // jQuery will be automatically set to _global.jQuery in applyBindings
+    // jQuery will be automatically set to globalThis.jQuery in applyBindings
     // if it is (strictly equal to) undefined.  Set it to false or null to
     // disable automatically setting jQuery.
-  jQuery: _global && _global.jQuery,
+  jQuery: globalThis.jQuery,
 
-  Promise: _global && _global.Promise,
+  Promise: globalThis.Promise,
 
   taskScheduler: null,
 
   debug: false,
 
-  global: _global,
-  document: _global.document,
+  global: globalThis,
+  document: globalThis.document,
 
     // Filters for bindings
     //   data-bind="expression | filter_1 | filter_2"


### PR DESCRIPTION
This should make the default build safer by preventing access to things like document and fetch. For backwards compatibility, I think we need to keep `window` the bindingGlobals for the knockout build.