### PR TITLE
Re-enable knockout build tests and fix dummyTemplateEngine import

### DIFF
--- a/builds/knockout/Makefile
+++ b/builds/knockout/Makefile
@@ -3,9 +3,6 @@ include ../../tools/build.mk
 
 iife-global-name := ko
 
-test:
-	@echo "Disabled pending fixes to build process"
-
 default::
 	$(MAKE) browser
 

--- a/builds/knockout/spec/crossWindowBehaviors.js
+++ b/builds/knockout/spec/crossWindowBehaviors.js
@@ -1,4 +1,4 @@
-
+import { dummyTemplateEngine } from "./templatingBehaviors";
 
 describe('Cross-window support', function() {
     it('Should work in another window', function () {

--- a/builds/knockout/spec/templatingBehaviors.js
+++ b/builds/knockout/spec/templatingBehaviors.js
@@ -1,5 +1,5 @@
 
-var dummyTemplateEngine = function (templates) {
+export var dummyTemplateEngine = function (templates) {
     var inMemoryTemplates = templates || {};
     var inMemoryTemplateData = {};
 


### PR DESCRIPTION
Fixes #162 though I'm not quite sure it's the right way.