### PR TITLE
172 build exports 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ bump:
 
 # from-git "identify packages tagged by lerna version and publish them to npm."
 # from-package "packages where the latest version is not present in the registry"
-publish-unpublished: build
+publish-unpublished: all link
 	$(LERNA) publish from-package
 
 package-lock.json: package.json packages/*/package.json
@@ -58,6 +58,7 @@ outdated-upgrade:
 install: package-lock.json
 
 clean:
+	rm -rf node_modules/
 	rm -f package-lock.json
 	rm -rf packages/*/dist/*
 	rm -rf packages/*/package-lock.json

--- a/builds/knockout/package.json
+++ b/builds/knockout/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.0-beta1.0",
+  "version": "4.0.0-beta1.1",
   "name": "@tko/build.knockout",
   "description": "Knockout makes it easier to create rich, responsive UIs with JavaScript",
   "homepage": "https://tko.io",

--- a/builds/knockout/package.json
+++ b/builds/knockout/package.json
@@ -66,7 +66,7 @@
   "exports": {
     ".": {
       "require": "./dist/index.cjs",
-      "import": "./dist/index.js"
+      "import": "./dist/index.mjs"
     },
     "./helpers/*": "./helpers/*"
   }

--- a/builds/reference/package.json
+++ b/builds/reference/package.json
@@ -48,7 +48,7 @@
   "exports": {
     ".": {
       "require": "./dist/index.cjs",
-      "import": "./dist/index.js"
+      "import": "./dist/index.mjs"
     },
     "./helpers/*": "./helpers/*"
   },

--- a/builds/reference/package.json
+++ b/builds/reference/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.0-beta1.0",
+  "version": "4.0.0-beta1.1",
   "name": "@tko/build.reference",
   "description": "The TKO Reference Build",
   "repository": {

--- a/builds/reference/src/index.ts
+++ b/builds/reference/src/index.ts
@@ -21,7 +21,7 @@ import { bindings as componentBindings } from '@tko/binding.component'
 import { filters } from '@tko/filter.punches'
 
 import components from '@tko/utils.component'
-import { createElement, Fragment } from 'utils.jsx'
+import { createElement, Fragment } from '@tko/utils.jsx'
 
 const builder = new Builder({
   filters,

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "useWorkspaces": true,
-  "version": "4.0.0-beta1.0",
+  "version": "4.0.0-beta1.1",
   "lerna": "4.0.0"
 }

--- a/tools/build.mk
+++ b/tools/build.mk
@@ -17,11 +17,12 @@ ESBUILD := npx esbuild
 .SUFFIXES: .ts .js
 
 default::
-	$(MAKE) esm commonjs
+	$(MAKE) esm commonjs mjs
 
-esm: dist/index.js
-commonjs: dist/index.cjs
 browser: dist/browser.min.js
+commonjs: dist/index.cjs
+esm: dist/index.js
+mjs: dist/index.mjs
 
 *.ts:
 
@@ -43,6 +44,17 @@ dist/index.js: $(src) package.json
 		--define:BUILD_VERSION='"${version}"' \
 		--sourcemap=external \
 		--outdir=dist/ \
+		$(src)
+
+dist/index.mjs: $(src) package.json
+	@echo "[make] Compiling ${package} => $@"
+	$(ESBUILD) \
+		--platform=neutral \
+		--log-level=$(log-level) \
+		--banner:js="$(banner) MJS" \
+		--define:BUILD_VERSION='"${version}"' \
+		--sourcemap=external \
+		--outfile=dist/index.mjs \
 		src/index.ts
 
 # Build a CommonJS bundle, targetting ES6.


### PR DESCRIPTION
This refines the build process and adds the `dist/index.mjs` build.

@mbest @SteveSanderson @rniemeyer @danieldickison @felipesantoz @ctcarton Just a heads up that we now have `4.0.0-beta1.1` version of TKO published to NPM (based on this branch).

I don't think we have the capacity yet to handle any attention to it being the first beta, but since we've been using TKO with an alpha designation in production with thousands of users for years it's probably due for the bump in confidence for those who go looking for it.

Happy to discuss & chat if anyone's interested -- feel free to ping me.