### PR TITLE
Root filter not transitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 For TODO between alpha and release, see https://github.com/knockout/tko/issues/1
 
+## Beta 1.6
+
+- Fix |filter1|filter2 filter2 not having root
+- In the Knockout build, don't convert evil twins (`==`/`!=`) to strict counterparts (`===`/`!==`)
+
 ## Beta 1.5
 
 - Make optional chaining the default for property lookups

--- a/builds/reference/src/index.ts
+++ b/builds/reference/src/index.ts
@@ -23,6 +23,12 @@ import { filters } from '@tko/filter.punches'
 import components from '@tko/utils.component'
 import { createElement, Fragment } from '@tko/utils.jsx'
 
+import { overloadOperator } from 'packages/utils.parser'
+
+/** Overload "evil twins" with strict equivalents */
+overloadOperator('==', (a, b) => a === b)
+overloadOperator('!=', (a, b) => a !== b)
+
 const builder = new Builder({
   filters,
   provider: new MultiProvider({

--- a/packages/utils.parser/spec/filterBehaviors.ts
+++ b/packages/utils.parser/spec/filterBehaviors.ts
@@ -87,4 +87,25 @@ describe('filters', function () {
     assert.equal(p.b(), 'ttey')
     assert.equal(p.c(), 'ttez')
   })
+
+  describe('root', () => {
+    let _testRoot = null
+    options.filters.setRoot = function (v) {
+      _testRoot = this
+    }
+
+    it('preserves the root across a single filter', () => {
+      const ourRoot = ctxStub({v: 'tt'})
+      const p = new Parser().parse('b: v | setRoot', ourRoot)
+      p.b()
+      assert.equal(_testRoot, ourRoot)
+    })
+
+    it('preserves the root across a multiple filters', () => {
+      const ourRoot = ctxStub({v: 'tt'})
+      const p = new Parser().parse('b: v | uppercase | setRoot', ourRoot)
+      p.b()
+      assert.strictEqual(_testRoot.lookup, ourRoot.lookup)
+    })
+  })
 })

--- a/packages/utils.parser/src/Parser.ts
+++ b/packages/utils.parser/src/Parser.ts
@@ -433,14 +433,14 @@ export default class Parser {
       ch = this.white()
     }
 
-    var filter = function filter (value, ignored, context, globals, node) {
+    function filter (value, ignored, context, globals, node) {
       var argValues = [value]
 
       for (var i = 0, j = args.length; i < j; ++i) {
         argValues.push(Node.value_of(args[i], context, globals, node))
       }
 
-      return nextFilter(options.filters[name].apply(context, argValues))
+      return nextFilter(options.filters[name].apply(context, argValues), ignored, context, globals, node)
     }
 
   // Lowest precedence.
@@ -460,7 +460,7 @@ export default class Parser {
  *    allowed in this expression. When true (default), this method consumes
  *    subsequent comma-separated values.
  * @see {@link Parser.singleValueExpression}
- * 
+ *
  * @returns a function that computes the value of the expression
  *    when called or a primitive.
  */
@@ -555,7 +555,7 @@ export default class Parser {
 /**
  * Use this method to parse expressions that can be followed by additional markup
  * seperated by a comma, such as in bindings strings.
- * 
+ *
  * @returns an expression that cannot contain multiple values separated by commas.
  * @see {@link Parser.expression}
  */

--- a/packages/utils.parser/src/index.ts
+++ b/packages/utils.parser/src/index.ts
@@ -1,3 +1,4 @@
+import operators from './operators'
 
 export {default as Parser} from './Parser'
 export {default as Identifier} from './Identifier'
@@ -6,3 +7,11 @@ export {default as Ternary} from './Ternary'
 export {default as Node} from './Node'
 
 export {default as parseObjectLiteral} from './preparse'
+
+
+export function overloadOperator (op: string, fn: (a, b) => any, precedence?: number) {
+  operators[op] = fn
+  if (Number.isInteger(precedence)) {
+    operators[op].precedence = precedence
+  }
+}


### PR DESCRIPTION
- fix transitive filter $root being cleared
- make default ==/!= operators strict on the reference build