### PR TITLE
fix wrong variable: ua => userAgent

### DIFF
--- a/packages/utils/src/ie.ts
+++ b/packages/utils/src/ie.ts
@@ -15,7 +15,7 @@ const ieVersion = options.document && (function () {
   if (!version) {
     const userAgent = window.navigator.userAgent
     // Detect IE 10/11
-    return ua.match(/MSIE ([^ ]+)/) || ua.match(/rv:([^ )]+)/)
+    return userAgent.match(/MSIE ([^ ]+)/) || userAgent.match(/rv:([^ )]+)/)
   }
   return version > 4 ? version : undefined
 }())


### PR DESCRIPTION
'ua' is an undefined variable => 'userAgent' would be correct.
Actually, we can remove the complete IE support..