### PR TITLE
value.ts: isInputElement is undefined

### DIFF
--- a/packages/binding.core/src/value.ts
+++ b/packages/binding.core/src/value.ts
@@ -65,7 +65,7 @@ export class value extends BindingHandler {
   // Workaround for https://github.com/SteveSanderson/knockout/issues/122
   // IE doesn't fire "change" events on textboxes if the user selects a value from its autocomplete list
   get ieAutoCompleteHackNeeded () {
-    return ieVersion && isInputElement &&
+    return ieVersion && isInput &&
       this.$element.type == 'text' && this.$element.autocomplete != 'off' &&
       (!this.$element.form || this.$element.form.autocomplete != 'off')
   }


### PR DESCRIPTION
While working on #202 we found another bug:

`isInputElement` is an undefined property, `isInput` (L.56) will be correct. I have validate it with the original sources and the ko-issues [122](https://github.com/SteveSanderson/knockout/issues/122).

IE support isn't longer relevant these days. However, it just shouldn't be broken unconsciously.