### PR TITLE
fix) recovering jquery was broken

### DIFF
--- a/packages/bind/src/applyBindings.ts
+++ b/packages/bind/src/applyBindings.ts
@@ -379,8 +379,8 @@ export function applyBindingsToDescendants (viewModelOrBindingContext, rootNode)
 export function applyBindings (viewModelOrBindingContext, rootNode, extendContextCallback) {
   const asyncBindingsApplied = new Set()
   // If jQuery is loaded after Knockout, we won't initially have access to it. So save it here.
-  if (!options.jQuery === undefined && options.jQuery) {
-    options.jQuery = options.jQuery
+  if (!options.jQuery && globalThis.jQuery) {
+    options.jQuery = globalThis.jQuery
   }
 
   // rootNode is optional

--- a/packages/bind/src/applyBindings.ts
+++ b/packages/bind/src/applyBindings.ts
@@ -379,7 +379,7 @@ export function applyBindingsToDescendants (viewModelOrBindingContext, rootNode)
 export function applyBindings (viewModelOrBindingContext, rootNode, extendContextCallback) {
   const asyncBindingsApplied = new Set()
   // If jQuery is loaded after Knockout, we won't initially have access to it. So save it here.
-  if (!options.jQuery && globalThis.jQuery) {
+  if (options.jQuery === undefined && globalThis.jQuery) {
     options.jQuery = globalThis.jQuery
   }
 


### PR DESCRIPTION
I found a always-false-condition and a stange self-assignment: `options.jQuery = options.jQuery`. 

After comparing it with Knockout.js, i think the solution is clear (see https://github.com/knockout/knockout/blob/45e86bf0347cf742ca359bab051ea82fdfae7a5d/src/binding/bindingAttributeSyntax.js#L567)