### PR TITLE
Fix for hasFocus / checked binding if not applied via DataBindProvider

### DIFF
--- a/packages/binding.core/spec/checkedBehaviors.ts
+++ b/packages/binding.core/spec/checkedBehaviors.ts
@@ -4,13 +4,11 @@ import {
 } from '@tko/utils'
 
 import {
-    applyBindings
-    , applyBindingsToNode
+    applyBindings, applyBindingsToNode
 } from '@tko/bind'
 
 import {
-    observable,
-    observableArray
+    observable, observableArray
 } from '@tko/observable'
 
 import {
@@ -23,8 +21,6 @@ import { bindings as coreBindings } from '../dist'
 import { bindings as templateBindings } from '@tko/binding.template'
 
 import '@tko/utils/helpers/jasmine-13-helper'
-
-import $ from 'jquery'
 
 describe('Binding: Checked', function () {
   beforeEach(jasmine.prepareTestNode)
@@ -39,14 +35,17 @@ describe('Binding: Checked', function () {
   it('Checked Binding should update observable value if checked binding is applied in another CustomBinding', function () {
     const RadioGroupExample  = {
       init: (element: HTMLElement, valueAccessor: () => any) => {
-        let group = $(element);
-        let options = valueAccessor();
-        let items = options.items();
+        const group = element;
+        const options = valueAccessor();
+        const items = options.items();
 
         for (let i = 0; i < items.length; i++) {
-          let radioBox = $('<input type="radio">').appendTo(group);
+          //let radioBox = $('<input type="radio">').appendTo(group);
+          const radioInput = document.createElement('input');
+          radioInput.type = 'radio';
+          group.appendChild(radioInput);
 
-          applyBindingsToNode(radioBox[0], {
+          applyBindingsToNode(radioInput, {
             checked: items[i].checked,
             attr:{
               value: items[i].value
@@ -58,9 +57,9 @@ describe('Binding: Checked', function () {
 
     options.bindingProviderInstance.bindingHandlers.set("customBinding",  RadioGroupExample)
 
-    var $decision = observable("")
-    var yesOption = { value: "True", checked: $decision }
-    var noOption = { value: "False", checked: $decision }
+    const $decision = observable("")
+    const yesOption = { value: "True", checked: $decision }
+    const noOption = { value: "False", checked: $decision }
     
     testNode.innerHTML = '<div data-bind="customBinding: radioBoxProp"></div>'
     applyBindings({radioBoxProp: { items: observable([yesOption, noOption]) } }, testNode);

--- a/packages/binding.core/spec/hasfocusBehaviors.ts
+++ b/packages/binding.core/spec/hasfocusBehaviors.ts
@@ -3,8 +3,7 @@ import {
 } from '@tko/utils'
 
 import {
-    applyBindings
-    , applyBindingsToNode
+    applyBindings, applyBindingsToNode
 } from '@tko/bind'
 
 import {
@@ -22,8 +21,6 @@ import {
 import * as coreBindings from '../dist'
 
 import '@tko/utils/helpers/jasmine-13-helper'
-
-import $ from 'jquery';
 
 arrayForEach(['hasfocus', 'hasFocus'], binding => {
   describe(`Binding: ${binding}`, function () {
@@ -47,17 +44,17 @@ arrayForEach(['hasfocus', 'hasFocus'], binding => {
     it('Should set an observable value to be true on focus and false on blur even if the binding is applied through another binding', function () {
       const createElementWithHasFocusBinding  = {
         init: (element: HTMLElement, valueAccessor: () => any) => {
-          let parent = $(element);
-          let $hasFocus = valueAccessor();
+          const parent = element;
+          const $hasFocus = valueAccessor();
 
-          applyBindingsToNode(parent[0], { hasFocus: $hasFocus })
+          applyBindingsToNode(parent, { hasFocus: $hasFocus })
         }
       };
       options.bindingProviderInstance.bindingHandlers.set("customBinding",  createElementWithHasFocusBinding)
 
       testNode.innerHTML = `<input data-bind='customBinding: customProps' /><input />`
 
-      var $myVal = observable(false)
+      const $myVal = observable(false)
       applyBindings({customProps: $myVal}, testNode );
       const input = testNode.children[0] as HTMLInputElement;
 

--- a/packages/binding.core/src/checked.ts
+++ b/packages/binding.core/src/checked.ts
@@ -78,7 +78,7 @@ export var checked = {
           }
         }
         // valueAccessor(elemValue, {onlyIfChanged: true})
-        var modelValue = valueAccessor(elemValue, {onlyIfChanged: true});
+        const modelValue = valueAccessor(elemValue, {onlyIfChanged: true});
         if (isWriteableObservable(modelValue) && (modelValue.peek() !== elemValue)) {
           modelValue(elemValue);
         }

--- a/packages/binding.core/src/hasfocus.ts
+++ b/packages/binding.core/src/hasfocus.ts
@@ -4,9 +4,7 @@ import {
 } from '@tko/utils'
 
 import {
-    unwrap
-    , dependencyDetection
-    , isWriteableObservable
+    unwrap, dependencyDetection, isWriteableObservable
 } from '@tko/observable'
 
 var hasfocusUpdatingProperty = createSymbolOrString('__ko_hasfocusUpdating')
@@ -33,12 +31,8 @@ export var hasfocus = {
         }
         isFocused = (active === element)
       }
-      var modelValue = valueAccessor(isFocused, {onlyIfChanged: true});
-      // In the scenario that hasFocus is binded not via the DataBindProvider
-      // but as an example as a LegacyBinding HasFocus value changes were not fired
-      // the fix was transfered from ko 3.5 (Focusout event was not fired)
-      // This only replies the value if there are changes
-      // it won't effect if already set by valueAccessor (Parser.convertToAccessors)
+
+      const modelValue = valueAccessor(isFocused, {onlyIfChanged: true});
       if (isWriteableObservable(modelValue) && (modelValue.peek() !== isFocused)) {
         modelValue(isFocused);
       }


### PR DESCRIPTION

## Problem
> An observable on hasFocus binding would not fire on focus changes if the binding was not applied via the dataBindProvider (e.g. LegacyBinding)

## Testcase

```js
[...]
const createElementWithHasFocusBinding  = {
  init: (element: HTMLElement, valueAccessor: () => any) => {
    let parent = $(element);
    let $hasFocus = valueAccessor();
    
    applyBindingsToNode(parent[0], { hasFocus: $hasFocus })
    }
  };
options.bindingProviderInstance.bindingHandlers.set("customBinding",  createElementWithHasFocusBinding)

testNode.innerHTML = `<input data-bind='customBinding: customProps' />`

var $hasFocus= observable(false)
applyBindings({customProps: $hasFocus}, testNode );
[...]
```
## Fix 

```js
//  in hasFocus.ts
[...]
var modelValue = valueAccessor(isFocused, {onlyIfChanged: true});
if (isWriteableObservable(modelValue) && (modelValue.peek() !== isFocused)) {
  modelValue(isFocused);
}
[...]
```

Found this bug while migrating from ko to tko, we have a custom LegacyBinding that applies bindings itself.
So its not a ``DataBindProvider`` which would otherwise trigger ``Parser.ConvertToAccessor()`` and therefore override the ``value`` function.

```js
// in parser.ts
  convertToAccessors (result, context, globals, node) {
    objectForEach(result, (name, value) => {
      if (value instanceof Identifier) {
        Object.defineProperty(result, name, {
          value: function (optionalValue, options) {
            const currentValue = value.get_value(undefined, context, globals, node)
            if (arguments.length === 0) { return currentValue }
            const unchanged = optionalValue === currentValue
            if (options && options.onlyIfChanged && unchanged) { return }
            return value.set_value(optionalValue, context, globals) // <------------------------ THIS is missing
          }
        [...]
```

I guess after #202 is merged it would be best to migrate the hasFocus / checked / etc. Bindings like the ``value`` Binding which already inherites from ``BindingHandler`` that basically contains the same logic as my quick fix

```js
// in BindingHandler.ts
get value () { return this.valueAccessor() }
set value (v) {
  const va = this.valueAccessor()
  if (isWriteableObservable(va)) {
    va(v)
  } else {
    this.valueAccessor(v)
  }
}
```
