### PR TITLE
Potential fix for code scanning alert no. 48: Bad HTML filtering regexp

### DIFF
--- a/builds/knockout/helpers/jasmine.extensions.js
+++ b/builds/knockout/helpers/jasmine.extensions.js
@@ -32,8 +32,8 @@ jasmine.Matchers.prototype.toEqualOneOf = function (expectedPossibilities) {
 jasmine.Matchers.prototype.toContainHtml = function (expectedHtml, postProcessCleanedHtml) {
     var cleanedHtml = this.actual.innerHTML.toLowerCase().replace(/\r\n/g, "");
     // IE < 9 strips whitespace immediately following comment nodes. Normalize by doing the same on all browsers.
-    cleanedHtml = cleanedHtml.replace(/(<!--.*?-->)\s*/g, "$1");
-    expectedHtml = expectedHtml.replace(/(<!--.*?-->)\s*/g, "$1");
+    cleanedHtml = cleanedHtml.replace(/(<!--[\s\S]*?-->)\s*/g, "$1");
+    expectedHtml = expectedHtml.replace(/(<!--[\s\S]*?-->)\s*/g, "$1");
     // Also remove __ko__ expando properties (for DOM data) - most browsers hide these anyway but IE < 9 includes them in innerHTML
     cleanedHtml = cleanedHtml.replace(/ __ko__\d+=\"(ko\d+|null)\"/g, "");
     if (postProcessCleanedHtml) {


### PR DESCRIPTION
Potential fix for [https://github.com/knockout/tko/security/code-scanning/48](https://github.com/knockout/tko/security/code-scanning/48)

To fix the problem, we need to update the regular expression to correctly match HTML comments that span multiple lines. This can be achieved by allowing the dot (`.`) to match newline characters as well. In JavaScript, this can be done by using the `[\s\S]` pattern, which matches any whitespace or non-whitespace character, effectively allowing the dot to match newlines.

The best way to fix the problem without changing existing functionality is to update the regular expression on line 36 to use `[\s\S]` instead of `.`. This change will ensure that multiline comments are correctly matched and normalized.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
