### PR TITLE
Publish-Profile

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+#  Publish Package Workflow for https://docs.npmjs.com/trusted-publishers
+name: Publish Package
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+          
+      - run: npm install
+      - run: make
+      - run: make test-headless
+      - run: npm publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,4 +29,5 @@ jobs:
       - run: make test-headless
       - run: make test-headless-jquery
 
-      - run: npx lerna publish from-package --yes
+      - run: make link
+      - run: npx lerna publish from-package --yes --skip-npm --no-git-tag-version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           
       - run: npm install
+      
       - run: make
+      - run: make tsc
       - run: make test-headless
-      - run: npm publish
+      - run: make test-headless-jquery
+
+      - run: npx lerna publish from-package --yes


### PR DESCRIPTION
Here is the first iteration of a GitHub action release workflow based on a tag.

@brianmhunt, we need to configure a trusted publisher in the TKO organization. See https://docs.npmjs.com/trusted-publishers.

Furthermore, I see the following release steps:

1) Manually run the "make bump" command and set the version.
2) We push and tag this.
3) The GitHub action runs and publishes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new automated workflow that runs on tag pushes and executes environment setup, install, build, test, and publish steps to streamline release publication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->