### PR TITLE
Add Playground links to header and homepage

### DIFF
--- a/tko.io/astro.config.mjs
+++ b/tko.io/astro.config.mjs
@@ -18,7 +18,8 @@ export default defineConfig({
       customCss: ['./src/styles/tko.css'],
       components: {
         Banner: './src/components/Banner.astro',
-        Head: './src/components/Head.astro'
+        Head: './src/components/Head.astro',
+        Header: './src/components/Header.astro'
       },
       sidebar: [
         { label: 'Introduction', slug: 'index' },

--- a/tko.io/src/components/Header.astro
+++ b/tko.io/src/components/Header.astro
@@ -1,0 +1,108 @@
+---
+import config from 'virtual:starlight/user-config';
+
+import LanguageSelect from 'virtual:starlight/components/LanguageSelect';
+import Search from 'virtual:starlight/components/Search';
+import SiteTitle from 'virtual:starlight/components/SiteTitle';
+import SocialIcons from 'virtual:starlight/components/SocialIcons';
+import ThemeSelect from 'virtual:starlight/components/ThemeSelect';
+
+const shouldRenderSearch =
+	config.pagefind || config.components.Search !== '@astrojs/starlight/components/Search.astro';
+---
+
+<div class="header">
+	<div class="title-wrapper sl-flex">
+		<SiteTitle />
+	</div>
+	<div class="sl-flex print:hidden">
+		{shouldRenderSearch && <Search />}
+	</div>
+	<div class="sl-hidden md:sl-flex print:hidden right-group">
+		<a class="playground-link" href="/playground">Playground</a>
+		<div class="sl-flex social-icons">
+			<SocialIcons />
+		</div>
+		<ThemeSelect />
+		<LanguageSelect />
+	</div>
+</div>
+
+<style>
+	@layer starlight.core {
+		.header {
+			display: flex;
+			gap: var(--sl-nav-gap);
+			justify-content: space-between;
+			align-items: center;
+			height: 100%;
+		}
+
+		.title-wrapper {
+			overflow: clip;
+			padding: 0.25rem;
+			margin: -0.25rem;
+			min-width: 0;
+		}
+
+		.right-group,
+		.social-icons {
+			gap: 1rem;
+			align-items: center;
+		}
+		.social-icons::after {
+			content: '';
+			height: 2rem;
+			border-inline-end: 1px solid var(--sl-color-gray-5);
+		}
+
+		.playground-link {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.3rem;
+			padding: 0.3rem 0.75rem;
+			border-radius: 999px;
+			border: 1px solid var(--sl-color-accent);
+			background: transparent;
+			color: var(--sl-color-accent);
+			font-size: 0.82rem;
+			font-weight: 700;
+			text-decoration: none;
+			white-space: nowrap;
+			transition: background 140ms ease, color 140ms ease;
+		}
+
+		.playground-link:hover {
+			background: var(--sl-color-accent);
+			color: #fff;
+		}
+
+		@media (min-width: 50rem) {
+			:global(:root[data-has-sidebar]) {
+				--__sidebar-pad: calc(2 * var(--sl-nav-pad-x));
+			}
+			:global(:root:not([data-has-toc])) {
+				--__toc-width: 0rem;
+			}
+			.header {
+				--__sidebar-width: max(0rem, var(--sl-content-inline-start, 0rem) - var(--sl-nav-pad-x));
+				--__main-column-fr: calc(
+					(
+							100% + var(--__sidebar-pad, 0rem) - var(--__toc-width, var(--sl-sidebar-width)) -
+								(2 * var(--__toc-width, var(--sl-nav-pad-x))) - var(--sl-content-inline-start, 0rem) -
+								var(--sl-content-width)
+						) / 2
+				);
+				display: grid;
+				grid-template-columns:
+					minmax(
+						calc(var(--__sidebar-width) + max(0rem, var(--__main-column-fr) - var(--sl-nav-gap))),
+						auto
+					)
+					1fr
+					auto;
+				align-content: center;
+			}
+		}
+	}
+</style>

--- a/tko.io/src/content/docs/index.md
+++ b/tko.io/src/content/docs/index.md
@@ -10,6 +10,7 @@ description: Choose the right TKO build and get started with modern Knockout.
   <div class="landing-actions">
     <a class="landing-button landing-button--primary" href="/bindings/">Start with bindings</a>
     <a class="landing-button landing-button--secondary" href="/3to4/">Read the migration guide</a>
+    <a class="landing-button landing-button--secondary" href="/playground">Try the Playground</a>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary

- Playground pill button in the site header toolbar (next to GitHub icon)
- "Try the Playground" secondary button in the homepage hero actions row

Depends on #254 (playground page) being merged first.

## Test plan

- [ ] Header shows "Playground" button on desktop viewports
- [ ] Hero shows "Try the Playground" alongside existing buttons
- [ ] Both links navigate to `/playground`
- [ ] Header button hidden on mobile (follows Starlight's responsive behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned header with integrated site title, search functionality, language selection, theme toggle, and social icons for improved navigation.
  * Added "Try the Playground" call-to-action on the landing page to guide users to the interactive playground feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->