### PR TITLE
Replace live-example placeholders with inline code, add TSX playground buttons

### DIFF
--- a/tko.io/plugins/playground-button.js
+++ b/tko.io/plugins/playground-button.js
@@ -1,12 +1,14 @@
 /**
  * Expressive Code plugin: adds an "Open in Playground" button to code blocks.
  *
- * Handles two patterns:
+ * Handles three patterns:
  *   1. Self-contained HTML blocks with inline <script> tags
  *   2. Adjacent html + javascript code blocks (common in KO docs)
+ *   3. TSX/HTML tab pairs followed by a javascript block
  *
  * For pattern 2, when a ```javascript block follows a ```html block,
  * the plugin pairs them and adds the button to the HTML block.
+ * For pattern 3 (tsx-tabs), the TSX block also gets a playground button.
  *
  * Replicates the exact same DOM structure and CSS as the built-in copy button:
  *   <a class="playground-open"><div></div></a>
@@ -88,8 +90,9 @@ function addPlaygroundButton(renderData, html, js) {
 }
 
 export function pluginPlaygroundButton() {
-  // Track pending HTML block for pairing with a following JS block
+  // Track pending blocks for pairing with a following JS block
   let pendingHtml = null
+  let pendingTsx = null
 
   return {
     name: 'playground-button',
@@ -173,28 +176,39 @@ export function pluginPlaygroundButton() {
 
     hooks: {
       postprocessRenderedBlock: ({ codeBlock, renderData }) => {
-        if (codeBlock.language === 'html') {
+        if (codeBlock.language === 'tsx') {
+          // TSX block (from tsx-tabs) — store for pairing with following JS block
+          pendingTsx = { html: codeBlock.code.trim(), renderData }
+        } else if (codeBlock.language === 'html') {
           const code = codeBlock.code
           const { html, js } = splitHtmlAndScript(code)
 
           if (js) {
             // Self-contained HTML block with inline <script> — add button now
             pendingHtml = null
+            pendingTsx = null
             addPlaygroundButton(renderData, html, js)
           } else {
             // HTML-only block — store for potential pairing with next JS block
             pendingHtml = { html: code.trim(), renderData }
           }
-        } else if (codeBlock.language === 'javascript' && pendingHtml) {
-          // JS block immediately after an HTML block — pair them
+        } else if (codeBlock.language === 'javascript' && (pendingHtml || pendingTsx)) {
+          // JS block after an HTML/TSX block — pair them
           const js = codeBlock.code.trim()
           if (js) {
-            addPlaygroundButton(pendingHtml.renderData, pendingHtml.html, js)
+            if (pendingHtml) {
+              addPlaygroundButton(pendingHtml.renderData, pendingHtml.html, js)
+            }
+            if (pendingTsx) {
+              addPlaygroundButton(pendingTsx.renderData, pendingTsx.html, js)
+            }
           }
           pendingHtml = null
+          pendingTsx = null
         } else {
           // Any other block type breaks the pairing
           pendingHtml = null
+          pendingTsx = null
         }
       }
     }

--- a/tko.io/public/agent-guide.md
+++ b/tko.io/public/agent-guide.md
@@ -30,25 +30,64 @@ foreach, if, ifnot, with, template:{name:'id'}, component:{name:'n',params:{}}
 
 Context variables inside foreach: $data, $parent, $root, $index (observable), $element.
 
-## JSX
+## TSX vs HTML Syntax
 
-Use `ko-*` attributes instead of `data-bind`:
+TKO supports two binding syntaxes. The documentation shows both side-by-side in tabbed code blocks.
 
-```jsx
-<span ko-text={obs} />
-<button ko-click={fn}>Label</button>
-<input ko-value={obs} />
-<ul ko-foreach={arr}><li ko-text="$data" /></ul>
-<div ko-if={cond}>...</div>
-<div ko-css={{ active: isActive }}>...</div>
+### HTML (data-bind) — runtime bindings
+
+```html
+<span data-bind="text: message"></span>
+<button data-bind="click: handler">Label</button>
+<ul data-bind="foreach: items"><li data-bind="text: $data"></li></ul>
 ```
 
-Render pattern (required for ko-* bindings to activate):
+- Bindings are **strings** evaluated at runtime by `ko.applyBindings(viewModel, element)`
+- Binding-context variables (`$data`, `$parent`, `$index`, `$root`) resolve at runtime
+- No build step needed — works directly in the browser
+- Playground: put HTML in the HTML editor, JS in the TSX editor, run
 
-```jsx
+### TSX (ko-*) — compile-time JSX expressions
+
+```tsx
+<span ko-text={message} />
+<button ko-click={handler}>Label</button>
+<ul ko-foreach={items}><li ko-text="$data" /></ul>
+```
+
+- `ko-*` attribute values in `{}` are **JavaScript expressions** evaluated at compile time by esbuild
+- Top-level variables (`message`, `handler`, `items`) must be defined in scope before the JSX
+- Binding-context variables inside `ko-foreach` children (like `$data`, `$parent`) use **string** syntax: `ko-text="$data"` (not `ko-text={$data}`)
+- Requires esbuild JSX transform + `tko.jsx.render()` to produce DOM nodes
+- `ko.applyBindings({}, container)` then activates the `ko-*` bindings on the rendered DOM
+
+### Key difference: compile-time vs runtime
+
+In HTML, `data-bind="foreach: people"` is a string — knockout evaluates `people` in the view model at runtime.
+
+In TSX, `ko-foreach={people}` is a JSX expression — esbuild resolves `people` as a JavaScript variable at compile time. The variable must exist in scope:
+
+```tsx
+// Variables must be defined before the JSX expression
+const people = ko.observableArray([...])
+
+const view = (
+  <ul ko-foreach={people}>
+    <li ko-text="name" />   {/* string — resolved by knockout at runtime */}
+  </ul>
+)
+
+const { node } = tko.jsx.render(view)
+root.appendChild(node)
+ko.applyBindings({}, root)
+```
+
+### Render pattern (required for ko-* bindings)
+
+```tsx
 const { node, dispose } = tko.jsx.render(<Component />)
 container.appendChild(node)
-tko.applyBindings({}, container) // activates ko-* bindings
+tko.applyBindings({}, container) // activates ko-* bindings on the DOM
 ```
 
 ## Browser TSX transform (esbuild-wasm)

--- a/tko.io/public/agent-testing.md
+++ b/tko.io/public/agent-testing.md
@@ -70,6 +70,62 @@ Console output appears in `#console-messages` as child elements.
 
 esbuild-wasm takes a few seconds to initialize on first load. The playground shows "esbuild ready" in `#esbuild-status` when it's ready. Code auto-runs after compilation.
 
+## Option 3: Testing doc page examples
+
+The TKO docs at tko.io show code examples as paired HTML + JavaScript blocks. Each pair has:
+- **TSX/HTML tabs** on the HTML block (showing both `ko-*` and `data-bind` syntax)
+- **"Open in Playground" button** on both tabs (opens the example in the playground)
+
+### Testing an HTML example from the docs
+
+Extract the HTML and JS from the code blocks and use Option 1 (static HTML file):
+
+```html
+<!DOCTYPE html>
+<html><body>
+  <!-- paste the HTML code block here -->
+  <script src="https://tko.io/lib/tko.js"></script>
+  <script>
+    window.ko = window.tko
+    // paste the JS code block here
+  </script>
+</body></html>
+```
+
+### Testing a TSX example from the docs
+
+TSX examples use `ko-*` attributes which require JSX compilation. Use Option 2 (playground).
+
+Important: `ko-*` attribute values in `{braces}` are **compile-time JavaScript expressions**, not runtime binding strings. Variables referenced in `ko-*={expr}` must be defined in the TSX scope before the JSX expression. Binding-context variables inside `ko-foreach` children should use **string syntax**: `ko-text="name"` not `ko-text={name}`.
+
+```tsx
+// 1. Define variables that ko-* attributes reference
+const people = ko.observableArray([...])
+
+// 2. JSX template using ko-* attributes
+const view = (
+  <ul ko-foreach={people}>
+    <li ko-text="$data" />
+  </ul>
+)
+
+// 3. Render and activate bindings
+const root = document.getElementById('root')
+const { node } = tko.jsx.render(view)
+root.appendChild(node)
+ko.applyBindings({}, root)
+```
+
+### Verifying playground links from doc pages
+
+Each "Open in Playground" button encodes `{ html, js }` in the URL hash. To verify:
+
+1. Navigate to the doc page (e.g., `http://localhost:4321/bindings/foreach-binding/`)
+2. Click "Open in Playground" on the HTML tab
+3. The playground should show the HTML in the HTML editor, JS in the TSX editor
+4. Wait for "esbuild ready", then the preview should render the example
+5. For TSX tab links: the playground currently receives TSX-style HTML — this requires manual restructuring to run (defining variables, wrapping in JSX, using `tko.jsx.render()`)
+
 ## Which option to use
 
 | Scenario | Option |
@@ -78,3 +134,4 @@ esbuild-wasm takes a few seconds to initialize on first load. The playground sho
 | JSX/TSX code | **Option 2** — playground has esbuild-wasm |
 | Quick observable/computed logic test | **Option 1** — no DOM needed, just script |
 | Sharing a runnable example with a human | **Option 2** — give them the playground URL |
+| Verifying doc page examples work | **Option 1** for HTML tab, **Option 2** for TSX tab |

--- a/tko.io/public/js/examples.js
+++ b/tko.io/public/js/examples.js
@@ -5,24 +5,6 @@ import { oneDark } from 'https://esm.sh/@codemirror/theme-one-dark@6.1.3';
 
 let esbuildInitialized = false;
 
-function parseLegacyExampleId(rawParams) {
-  const match = rawParams?.match(/id:\s*["']?([^"'}\s]+)["']?/i);
-  return match?.[1] || 'legacy-example';
-}
-
-function createLegacyExamplePlaceholder(exampleNode) {
-  const exampleId = parseLegacyExampleId(exampleNode.getAttribute('params') || '');
-  const container = document.createElement('div');
-  container.className = 'example-placeholder';
-  container.dataset.exampleId = exampleId;
-  container.innerHTML = `
-    <div class="example-placeholder__label">Live example in progress</div>
-    <p>This page still references the legacy example <code>${exampleId}</code>.</p>
-    <p>The interactive example system is being rebuilt for the Starlight site. Use the code snippets on this page as the current reference for now.</p>
-  `;
-  exampleNode.replaceWith(container);
-}
-
 async function initEsbuild() {
   if (!esbuildInitialized) {
     await esbuild.initialize({
@@ -158,8 +140,6 @@ if (document.readyState === 'loading') {
 }
 
 function initExamples() {
-  document.querySelectorAll('live-example').forEach(createLegacyExamplePlaceholder);
-
   // Find all code blocks with language 'jsx'
   const jsxBlocks = document.querySelectorAll('pre code.language-jsx');
   jsxBlocks.forEach(createExampleContainer);

--- a/tko.io/public/llms.txt
+++ b/tko.io/public/llms.txt
@@ -19,6 +19,15 @@
 - Playground: /playground
 - GitHub: https://github.com/knockout/tko
 
+## Two Binding Syntaxes
+
+HTML: `data-bind="text: msg"` — runtime strings, works with `ko.applyBindings(vm, el)`
+TSX: `ko-text={msg}` — compile-time JSX expressions, needs esbuild + `tko.jsx.render()`
+
+Inside `ko-foreach` children, binding-context vars use strings: `ko-text="$data"` (not `{$data}`)
+
+See /agent-guide.md for details.
+
 ## Docs
 
 /observables/ · /computed/ · /bindings/ · /components/ · /binding-context/ · /advanced/

--- a/tko.io/src/content/docs/bindings/attr-binding.md
+++ b/tko.io/src/content/docs/bindings/attr-binding.md
@@ -9,7 +9,20 @@ The `attr` binding provides a generic way to set the value of any attribute for 
 
 ### Example
 
-<live-example params='id: "attr"'></live-example>
+```html
+<a data-bind="attr: { href: url, title: details }">
+    Report
+</a>
+```
+
+```javascript
+var viewModel = {
+    url: ko.observable("year-end.html"),
+    details: ko.observable("Report including final year-end statistics")
+};
+
+ko.applyBindings(viewModel);
+```
 
 This will set the element's `href` attribute to `year-end.html` and the element's `title` attribute to `Report including final year-end statistics`.
 

--- a/tko.io/src/content/docs/bindings/click-binding.md
+++ b/tko.io/src/content/docs/bindings/click-binding.md
@@ -8,7 +8,24 @@ title: Click Binding
 The `click` binding adds an event handler so that your chosen JavaScript function will be invoked when the associated DOM element is clicked. This is most commonly used with elements like `button`, `input`, and `a`, but actually works with any visible DOM element.
 
 ### Example
-<live-example params='id: "click"'></live-example>
+```html
+<div>
+    You've clicked <span data-bind="text: numberOfClicks"></span> times
+    <button data-bind="click: incrementClickCounter">Click me</button>
+</div>
+```
+
+```javascript
+var viewModel = {
+    numberOfClicks: ko.observable(0),
+    incrementClickCounter: function() {
+        var previousCount = this.numberOfClicks();
+        this.numberOfClicks(previousCount + 1);
+    }
+};
+
+ko.applyBindings(viewModel);
+```
 
 
 Each time you click the button, this will invoke `incrementClickCounter()` on the view model, which in turn changes the view model state, which causes the UI to update.
@@ -30,7 +47,27 @@ Each time you click the button, this will invoke `incrementClickCounter()` on th
 When calling your handler, Knockout will supply the current model value as the first parameter. This is particularly useful if you're rendering
 some UI for each item in a collection, and you need to know which item's UI was clicked. For example,
 
-<live-example params='id: "click-places"'></live-example>
+```html
+<ul data-bind="foreach: places">
+    <li>
+        <span data-bind="text: $data"></span>
+        <button data-bind="click: $parent.removePlace">Remove</button>
+    </li>
+</ul>
+```
+
+```javascript
+function MyViewModel() {
+    var self = this;
+    self.places = ko.observableArray(['London', 'Paris', 'Tokyo']);
+
+    self.removePlace = function(place) {
+        self.places.remove(place);
+    };
+}
+
+ko.applyBindings(new MyViewModel());
+```
 
 Two points to note about this example:
 
@@ -45,7 +82,25 @@ Two points to note about this example:
 
 In some scenarios, you may need to access the DOM event object associated with your click event. Knockout will pass the event as the second parameter to your function, as in this example:
 
-<live-example params='id: "click-event"'></live-example>
+```html
+<button data-bind="click: myFunction">
+    Click me
+</button>
+```
+
+```javascript
+var viewModel = {
+    myFunction: function(data, event) {
+        if (event.shiftKey) {
+            //do something different when user has shift key down
+        } else {
+            //do normal action
+        }
+    }
+};
+
+ko.applyBindings(viewModel);
+```
 
 If you need to pass more parameters, one way to do it is by wrapping your handler in a function literal that takes in a parameter, as in this example:
 

--- a/tko.io/src/content/docs/bindings/enable-binding.md
+++ b/tko.io/src/content/docs/bindings/enable-binding.md
@@ -10,7 +10,25 @@ The `enable` binding causes the associated DOM element to be enabled only when t
 
 ### Example
 
-<live-example params='id: "enable-binding"'></live-example>
+```html
+<p>
+    <input type="checkbox" data-bind="checked: hasCellphone" />
+    I have a cellphone
+</p>
+<p>
+    Your cellphone number:
+    <input type="text" data-bind="value: cellphoneNumber, enable: hasCellphone" />
+</p>
+```
+
+```javascript
+var viewModel = {
+    hasCellphone: ko.observable(false),
+    cellphoneNumber: ""
+};
+
+ko.applyBindings(viewModel);
+```
 
 In this example, the "Your cellphone number" text box will initially be disabled. It will be enabled only when the user checks the box labelled "I have a cellphone".
 

--- a/tko.io/src/content/docs/bindings/foreach-binding.md
+++ b/tko.io/src/content/docs/bindings/foreach-binding.md
@@ -16,7 +16,29 @@ Of course, you can arbitrarily nest any number of `foreach` bindings along with 
 
 This example uses `foreach` to produce a read-only table with a row for each array entry.
 
-<live-example params='id: "foreach"'></live-example>
+```html
+<table>
+    <thead>
+        <tr><th>First name</th><th>Last name</th></tr>
+    </thead>
+    <tbody data-bind="foreach: people">
+        <tr>
+            <td data-bind="text: firstName"></td>
+            <td data-bind="text: lastName"></td>
+        </tr>
+    </tbody>
+</table>
+```
+
+```javascript
+ko.applyBindings({
+    people: [
+        { firstName: 'Bert', lastName: 'Bertington' },
+        { firstName: 'Charles', lastName: 'Charlesforth' },
+        { firstName: 'Denise', lastName: 'Dentiste' }
+    ]
+});
+```
 
 *Note: Table headers might disappear if the screen is small.*
 
@@ -24,7 +46,39 @@ This example uses `foreach` to produce a read-only table with a row for each arr
 
 The following example shows that, if your array is observable, then the UI will be kept in sync with changes to that array.
 
-<live-example params='id: "foreach-people"'></live-example>
+```html
+<h4>People</h4>
+<ul data-bind="foreach: people">
+    <li>
+        Name at position <span data-bind="text: $index"> </span>:
+        <span data-bind="text: name"> </span>
+        <a href="#" data-bind="click: $parent.removePerson">Remove</a>
+    </li>
+</ul>
+<button data-bind="click: addPerson">Add</button>
+```
+
+```javascript
+function AppViewModel() {
+    var self = this;
+
+    self.people = ko.observableArray([
+        { name: 'Bert' },
+        { name: 'Charles' },
+        { name: 'Denise' }
+    ]);
+
+    self.addPerson = function() {
+        self.people.push({ name: "New at " + new Date() });
+    };
+
+    self.removePerson = function() {
+        self.people.remove(this);
+    };
+}
+
+ko.applyBindings(new AppViewModel());
+```
 
 ### Parameters
 
@@ -49,7 +103,19 @@ As shown in the above examples, bindings within the `foreach` block can refer to
 
 But what if you want to refer to the array entry itself (not just one of its properties)? In that case, you can use the [special context property](../../binding-context/binding-context/) `$data`. Within a `foreach` block, it means "the current item". For example,
 
-<live-example params='id: "foreach-$data"'></live-example>
+```html
+<ul data-bind="foreach: months">
+    <li>
+        The current item is: <b data-bind="text: $data"></b>
+    </li>
+</ul>
+```
+
+```javascript
+ko.applyBindings({
+    months: [ 'Jan', 'Feb', 'Mar', 'etc' ]
+});
+```
 
 If you wanted, you could use `$data` as a prefix when referencing properties on each entry. For example, you could rewrite part of [Example 1](#example_1_iterating_over_an_array) as follows:
 
@@ -87,7 +153,29 @@ As described in Note 1, you can refer to each array entry using the `$data` [con
 
 Now anywhere inside this `foreach` loop, bindings will be able to refer to `person` to access the current array item, from the `people` array, that is being rendered. This can be especially useful in scenarios where you have nested `foreach` blocks and you need to refer to an item declared at a higher level in the hierarchy. For example:
 
-<live-example params='id: "foreach-cats"'></live-example>
+```html
+<ul data-bind="foreach: { data: categories, as: 'category' }">
+    <li>
+        <ul data-bind="foreach: { data: items, as: 'item' }">
+            <li>
+                <span data-bind="text: category.name"></span>:
+                <span data-bind="text: item"></span>
+            </li>
+        </ul>
+    </li>
+</ul>
+```
+
+```javascript
+var viewModel = {
+    categories: ko.observableArray([
+        { name: 'Fruit', items: [ 'Apple', 'Orange', 'Banana' ] },
+        { name: 'Vegetables', items: [ 'Celery', 'Corn', 'Spinach' ] }
+    ])
+};
+
+ko.applyBindings(viewModel);
+```
 
 
 Tip: Remember to pass a *string literal value* to `as` (e.g., `as: 'category'`, *not* `as: category`), because you are giving a name for a new variable, not reading the value of a variable that already exists.
@@ -111,7 +199,20 @@ In this example, there isn't anywhere to put a normal `foreach` binding. You can
 
 To handle this, you can use the *containerless control flow syntax*, which is based on comment tags. For example,
 
-<live-example params='id: "foreach-virtual"'></live-example>
+```html
+<ul>
+    <li class="header">Header item</li>
+    <!-- ko foreach: myItems -->
+        <li>Item <span data-bind="text: $data"></span></li>
+    <!-- /ko -->
+</ul>
+```
+
+```javascript
+ko.applyBindings({
+    myItems: [ 'A', 'B', 'C' ]
+});
+```
 
 The `<!-- ko -->` and `<!-- /ko -->` comments act as start/end markers, defining a "virtual element" that contains the markup inside. Knockout understands this virtual element syntax and binds as if you had a real container element.
 
@@ -145,7 +246,29 @@ If you need to run some further custom logic on the generated DOM elements, you 
 
 Here's a trivial example that uses `afterAdd` to apply the classic "yellow fade" effect to newly-added items. It requires the [jQuery Color plugin](https://github.com/jquery/jquery-color) to enable animation of background colors.
 
-<live-example params='id: "foreach-afteradd"'></live-example>
+```html
+<ul data-bind="foreach: { data: myItems, afterAdd: yellowFadeIn }">
+    <li data-bind="text: $data"></li>
+</ul>
+
+<button data-bind="click: addItem">Add</button>
+```
+
+```javascript
+ko.applyBindings({
+    myItems: ko.observableArray([ 'A', 'B', 'C' ]),
+    yellowFadeIn: function(element, index, data) {
+        if (element.nodeType === 1) {
+            element.style.transition = 'background-color 1s';
+            element.style.backgroundColor = 'yellow';
+            setTimeout(function() {
+                element.style.backgroundColor = '';
+            }, 200);
+        }
+    },
+    addItem: function() { this.myItems.push('New item'); }
+});
+```
 
 Full details:
 

--- a/tko.io/src/content/docs/bindings/hasfocus-binding.md
+++ b/tko.io/src/content/docs/bindings/hasfocus-binding.md
@@ -15,14 +15,45 @@ This is useful if you're building sophisticated forms in which editable elements
 ### Example 1: The basics
 This example simply displays a message if the textbox currently has focus, and uses a button to show that you can trigger focus programmatically.
 
-<live-example params='id: "hasfocus-binding"'></live-example>
+```html
+<input data-bind="hasFocus: isSelected" />
+<button data-bind="click: setIsSelected">Focus programmatically</button>
+<span data-bind="visible: isSelected">The textbox has focus</span>
+```
+
+```javascript
+var viewModel = {
+    isSelected: ko.observable(false),
+    setIsSelected: function() { this.isSelected(true); }
+};
+
+ko.applyBindings(viewModel);
+```
 
 
 ### Example 2: Click-to-edit
 
 Because the `hasFocus` binding works in both directions (setting the associated value focuses or unfocuses the element; focusing or unfocusing the element sets the associated value), it's a convenient way to toggle an "edit" mode. In this example, the UI displays either a `<span>` or an `<input>` element depending on the model's `editing` property. Unfocusing the `<input>` element sets `editing` to `false`, so the UI switches out of "edit" mode.
 
-<live-example params='id: "hasfocus-edit"'></live-example>
+```html
+<p>
+    Name:
+    <b data-bind="visible: !editing(), text: name, click: edit">&nbsp;</b>
+    <input data-bind="visible: editing, value: name, hasFocus: editing" />
+</p>
+<p><em>Click the name to edit it; click elsewhere to apply changes.</em></p>
+```
+
+```javascript
+function PersonViewModel(name) {
+    this.name = ko.observable(name);
+    this.editing = ko.observable(false);
+
+    this.edit = function() { this.editing(true); };
+}
+
+ko.applyBindings(new PersonViewModel("Bert Bertington"));
+```
 
 
 ### Parameters

--- a/tko.io/src/content/docs/bindings/if-binding.md
+++ b/tko.io/src/content/docs/bindings/if-binding.md
@@ -14,7 +14,17 @@ The `if` binding causes a section of markup to appear in your document (and to h
 
 This example shows that the `if` binding can dynamically add and remove sections of markup as observable values change.
 
-<live-example params='id: "if-binding"'></live-example>
+```html
+<label><input type="checkbox" data-bind="checked: displayMessage" /> Display message</label>
+
+<div data-bind="if: displayMessage">Here is a message. Astonishing.</div>
+```
+
+```javascript
+ko.applyBindings({
+    displayMessage: ko.observable(false)
+});
+```
 
 ### Example 2
 

--- a/tko.io/src/content/docs/bindings/text-binding.md
+++ b/tko.io/src/content/docs/bindings/text-binding.md
@@ -11,7 +11,18 @@ The `text` binding causes the associated DOM element to display the text value o
 Typically this is useful with elements like `<span>` or `<em>` that traditionally display text, but technically you can use it with any element.
 
 ### Example
-<live-example params='id: "text-binding"'></
+```html
+Today's message is: <span data-bind="text: myMessage"></span>
+```
+
+```javascript
+var viewModel = {
+    myMessage: ko.observable() // Initially blank
+};
+viewModel.myMessage("Hello, world!"); // Text appears
+
+ko.applyBindings(viewModel);
+```
 
 
 ### Parameters
@@ -34,7 +45,20 @@ If you want to detemine text programmatically, one option is to create a [comput
 
 For example,
 
-<live-example params='id: text-computed'></live-example>
+```html
+The item is <span data-bind="text: priceRating"></span> today.
+```
+
+```javascript
+var viewModel = {
+    price: ko.observable(24.95)
+};
+viewModel.priceRating = ko.pureComputed(function() {
+    return this.price() > 50 ? "expensive" : "affordable";
+}, viewModel);
+
+ko.applyBindings(viewModel);
+```
 
 Now, the text will switch between "expensive" and "affordable" as needed whenever `price` changes.
 

--- a/tko.io/src/content/docs/bindings/textInput-binding.md
+++ b/tko.io/src/content/docs/bindings/textInput-binding.md
@@ -11,7 +11,19 @@ The `textInput` binding links a text box (`<input>`) or text area (`<textarea>`)
 
 ### Example
 
-<live-example params='id: "textinput-binding"'></live-example>
+```html
+<p>Login name: <input data-bind="textInput: userName" /></p>
+<p>Password: <input type="password" data-bind="textInput: userPassword" /></p>
+
+<pre data-bind="text: ko.toJSON($root, null, 2)"></pre>
+```
+
+```javascript
+ko.applyBindings({
+    userName: ko.observable(""),
+    userPassword: ko.observable("abc")
+});
+```
 
 ### Parameters
 

--- a/tko.io/src/content/docs/bindings/value-binding.md
+++ b/tko.io/src/content/docs/bindings/value-binding.md
@@ -17,7 +17,19 @@ Note: If you're working with checkboxes or radio buttons, use [the `checked` bin
 
 ### Example
 
-<live-example params='id: "value-binding"'></live-example>
+```html
+<p>Login name: <input data-bind="value: userName" /></p>
+<p>Password: <input type="password" data-bind="value: userPassword" /></p>
+```
+
+```javascript
+var viewModel = {
+    userName: ko.observable(""),
+    userPassword: ko.observable("abc")
+};
+
+ko.applyBindings(viewModel);
+```
 
 ### Parameters
 

--- a/tko.io/src/content/docs/components/component-binding.md
+++ b/tko.io/src/content/docs/components/component-binding.md
@@ -12,7 +12,28 @@ The `component` binding injects a specified [component](component-overview.html)
 
 ### Live example
 
-<live-example params='id: "component-binding"'></live-example>
+```html
+<h4>First instance, without parameters</h4>
+<div data-bind='component: "message-editor"'></div>
+
+<h4>Second instance, passing parameters</h4>
+<div data-bind='component: {
+    name: "message-editor",
+    params: { initialText: "Hello, world!" }
+}'></div>
+```
+
+```javascript
+ko.components.register('message-editor', {
+    viewModel: function(params) {
+        this.text = ko.observable(params && params.initialText || '');
+    },
+    template: 'Message: <input data-bind="value: text" /> '
+            + '(length: <span data-bind="text: text().length"></span>)'
+});
+
+ko.applyBindings();
+```
 
 Note: In more realistic cases, you would typically load component viewmodels and templates from external files, instead of hardcoding them into the registration. See [an example](#component-overview) and [registration documentation](#component-registration).
 

--- a/tko.io/src/content/docs/components/component-custom-elements.md
+++ b/tko.io/src/content/docs/components/component-custom-elements.md
@@ -33,7 +33,23 @@ This allows for a very modern, [WebComponents](http://www.w3.org/TR/components-i
 This example declares a component, and then injects two instances of it into a view. See the source code below.
 
 ```html
-<live-example params='id: "component-custom-element"'></live-example>
+<h4>First instance, without parameters</h4>
+<message-editor></message-editor>
+
+<h4>Second instance, passing parameters</h4>
+<message-editor params='initialText: "Hello, world!"'></message-editor>
+```
+
+```javascript
+ko.components.register('message-editor', {
+    viewModel: function(params) {
+        this.text = ko.observable(params.initialText || '');
+    },
+    template: 'Message: <input data-bind="value: text" /> '
+            + '(length: <span data-bind="text: text().length"></span>)'
+});
+
+ko.applyBindings();
 ```
 
 Note: In more realistic cases, you would typically load component viewmodels and templates from external files, instead of hardcoding them into the registration. See [an example](#component-overview.html#example-loading-the-likedislike-widget-from-external-files-on-demand) and [registration documentation](#component-registration).
@@ -119,7 +135,41 @@ The component can then choose to use the supplied DOM nodes as part of its outpu
 
 For example, the `my-special-list` component's template can reference `$componentTemplateNodes` so that its output includes the supplied markup. Here's the complete working example:
 
-<live-example params='id: "component-markdown-example"'></live-example>
+```html
+<!-- This could be in a separate file -->
+<template id="my-special-list-template">
+    <h3>Here is a special list</h3>
+
+    <ul data-bind="foreach: { data: myItems, as: 'myItem' }">
+        <li>
+            <h4>Here is another one of my special items</h4>
+            <!-- ko template: { nodes: $componentTemplateNodes, data: myItem } --><!-- /ko -->
+        </li>
+    </ul>
+</template>
+
+<my-special-list params="items: someArrayOfPeople">
+    <!-- Look, I'm putting markup inside a custom element -->
+    The person <em data-bind="text: name"></em>
+    is <em data-bind="text: age"></em> years old.
+</my-special-list>
+```
+
+```javascript
+ko.components.register('my-special-list', {
+    template: { element: 'my-special-list-template' },
+    viewModel: function(params) {
+        this.myItems = params.items;
+    }
+});
+
+ko.applyBindings({
+    someArrayOfPeople: ko.observableArray([
+        { name: 'Lewis', age: 56 },
+        { name: 'Hathaway', age: 34 }
+    ])
+});
+```
 
 This "special list" example does nothing more than insert a heading above each list item. But the same technique can be used to create sophisticated grids, dialogs, tab sets, and so on, since all that is needed for such UI elements is common UI markup (e.g., to define the grid or dialog's heading and borders) wrapped around arbitrary supplied markup.
 

--- a/tko.io/src/content/docs/components/index.md
+++ b/tko.io/src/content/docs/components/index.md
@@ -27,13 +27,95 @@ This pattern is beneficial for large applications, because it **simplifies devel
 
 To get started, you can register a component using `ko.components.register` (technically, registration is optional, but it's the easiest way to get started). A component definition specifies a `viewModel` and `template`. For example:
 
-<live-example params='id: "component-like"'></live-example>
+```html
+<ul data-bind="foreach: products">
+    <li class="product">
+        <strong data-bind="text: name"></strong>
+        <like-widget params="value: userRating"></like-widget>
+    </li>
+</ul>
+```
+
+```javascript
+ko.components.register('like-widget', {
+    viewModel: function(params) {
+        this.chosenValue = params.value;
+        this.like = function() { this.chosenValue('like'); }.bind(this);
+        this.dislike = function() { this.chosenValue('dislike'); }.bind(this);
+    },
+    template:
+        '<div class="like-or-dislike" data-bind="visible: !chosenValue()">'
+      +     '<button data-bind="click: like">Like it</button> '
+      +     '<button data-bind="click: dislike">Dislike it</button>'
+      + '</div>'
+      + '<div class="result" data-bind="visible: chosenValue">'
+      +     'You <strong data-bind="text: chosenValue"></strong> it'
+      + '</div>'
+});
+
+function Product(name, rating) {
+    this.name = name;
+    this.userRating = ko.observable(rating || null);
+}
+
+function MyViewModel() {
+    this.products = [
+        new Product('Garlic bread'),
+        new Product('Pain au chocolat'),
+        new Product('Seagull spaghetti', 'like')
+    ];
+}
+
+ko.applyBindings(new MyViewModel());
+```
 
 **Normally, you'd load the view model and template from external files** instead of declaring them inline like this. We'll get to that later.
 
 Now, to use this component, you can reference it from any other view in your application, either using the [`component` binding](#component-binding) or using a [custom element](#component-custom-elements). Here's a live example that uses it as a custom element:
 
-<live-example params='id: "component-overview"'></live-example>
+```html
+<ul data-bind="foreach: products">
+    <li class="product">
+        <strong data-bind="text: name"></strong>
+        <like-or-dislike params="value: userRating"></like-or-dislike>
+    </li>
+</ul>
+<button data-bind="click: addProduct">Add a product</button>
+```
+
+```javascript
+ko.components.register('like-or-dislike', {
+    viewModel: function(params) {
+        this.chosenValue = params.value;
+        this.like = function() { this.chosenValue('like'); }.bind(this);
+        this.dislike = function() { this.chosenValue('dislike'); }.bind(this);
+    },
+    template:
+        '<div class="like-or-dislike" data-bind="visible: !chosenValue()">'
+      +     '<button data-bind="click: like">Like it</button> '
+      +     '<button data-bind="click: dislike">Dislike it</button>'
+      + '</div>'
+      + '<div class="result" data-bind="visible: chosenValue">'
+      +     'You <strong data-bind="text: chosenValue"></strong> it'
+      + '</div>'
+});
+
+function Product(name, rating) {
+    this.name = name;
+    this.userRating = ko.observable(rating || null);
+}
+
+function MyViewModel() {
+    this.products = ko.observableArray();
+}
+
+MyViewModel.prototype.addProduct = function() {
+    var name = 'Product ' + (this.products().length + 1);
+    this.products.push(new Product(name));
+};
+
+ko.applyBindings(new MyViewModel());
+```
 
 
 In this example, the component both displays and edits an observable property called `userRating` on the `Product` view model class.

--- a/tko.io/src/content/docs/computed/computed-pure.md
+++ b/tko.io/src/content/docs/computed/computed-pure.md
@@ -49,7 +49,41 @@ You can use the *pure* feature for any computed observable that follows the [*pu
 
 In the following example of a simple wizard interface, the `fullName` *pure* computed is only bound to the view during the final step and so is only updated when that step is active.
 
-<live-example params='id: "pure-computed"'></live-example>
+```html
+<div class="log" data-bind="text: computedLog"></div>
+<!--ko if: step() == 0-->
+    <p>First name: <input data-bind="textInput: firstName" /></p>
+<!--/ko-->
+<!--ko if: step() == 1-->
+    <p>Last name: <input data-bind="textInput: lastName" /></p>
+<!--/ko-->
+<!--ko if: step() == 2-->
+    <div>Prefix: <select data-bind="value: prefix, options: ['Mr.', 'Ms.','Mrs.','Dr.']"></select></div>
+    <h2>Hello, <span data-bind="text: fullName"> </span>!</h2>
+<!--/ko-->
+<p><button type="button" data-bind="click: next">Next</button></p>
+```
+
+```javascript
+function AppData() {
+    this.firstName = ko.observable('John');
+    this.lastName = ko.observable('Burns');
+    this.prefix = ko.observable('Dr.');
+    this.computedLog = ko.observable('Log: ');
+    this.fullName = ko.pureComputed(function () {
+        var value = this.prefix() + " " + this.firstName() + " " + this.lastName();
+        this.computedLog(this.computedLog.peek() + value + '; ');
+        return value;
+    }, this);
+
+    this.step = ko.observable(0);
+    this.next = function () {
+        this.step(this.step() === 2 ? 0 : this.step() + 1);
+    };
+}
+
+ko.applyBindings(new AppData());
+```
 
 ### When *not* to use a *pure* computed observable
 

--- a/tko.io/src/content/docs/computed/computed-writable.md
+++ b/tko.io/src/content/docs/computed/computed-writable.md
@@ -17,7 +17,34 @@ Writable computed observables are a powerful feature with a wide range of possib
 
 Going back to the classic "first name + last name = full name" example, you can turn things back-to-front: make the `fullName` computed observable writable, so that the user can directly edit the full name, and their supplied value will be parsed and mapped back to the underlying `firstName` and `lastName` observables. In this example, the `write` callback handles incoming values by splitting the incoming text into "firstName" and "lastName" components, and writing those values back to the underlying observables.
 
-<live-example params='id: "computed-writable"'></live-example>
+```html
+<div>First name: <span data-bind="text: firstName"></span></div>
+<div>Last name: <span data-bind="text: lastName"></span></div>
+<div class="heading">Hello, <input data-bind="textInput: fullName"/></div>
+```
+
+```javascript
+function MyViewModel() {
+    this.firstName = ko.observable('Planet');
+    this.lastName = ko.observable('Earth');
+
+    this.fullName = ko.pureComputed({
+        read: function () {
+            return this.firstName() + " " + this.lastName();
+        },
+        write: function (value) {
+            var lastSpacePos = value.lastIndexOf(" ");
+            if (lastSpacePos > 0) {
+                this.firstName(value.substring(0, lastSpacePos));
+                this.lastName(value.substring(lastSpacePos + 1));
+            }
+        },
+        owner: this
+    });
+}
+
+ko.applyBindings(new MyViewModel());
+```
 
 This is the exact opposite of the classic "Hello World" example, in that here the first and last names are not editable, but the combined full name is editable.
 
@@ -27,14 +54,64 @@ The preceding view model code demonstrates the *single parameter syntax* for ini
 
 When presenting the user with a list of selectable items, it is often useful to include a method to select or deselect all of the items. This can be represented quite intuitively with a boolean value that represents whether all items are selected. When set to `true` it will select all items, and when set to `false` it will deselect them.
 
-<live-example params='id: "computed-writable-deselect"'></live-example>
+```html
+<div class="heading">
+    <input type="checkbox" data-bind="checked: selectedAllProduce" title="Select all/none"/> Produce
+</div>
+<div data-bind="foreach: produce">
+    <label>
+        <input type="checkbox" data-bind="checkedValue: $data, checked: $parent.selectedProduce"/>
+        <span data-bind="text: $data"></span>
+    </label>
+</div>
+```
+
+```javascript
+function MyViewModel() {
+    this.produce = [ 'Apple', 'Banana', 'Celery', 'Corn', 'Orange', 'Spinach' ];
+    this.selectedProduce = ko.observableArray([ 'Corn', 'Orange' ]);
+    this.selectedAllProduce = ko.pureComputed({
+        read: function () {
+            return this.selectedProduce().length === this.produce.length;
+        },
+        write: function (value) {
+            this.selectedProduce(value ? this.produce.slice(0) : []);
+        },
+        owner: this
+    });
+}
+
+ko.applyBindings(new MyViewModel());
+```
 
 
 ### Example 3: A value converter
 
 Sometimes you might want to represent a data point on the screen in a different format than its underlying storage. For example, you might want to store a price as a raw float value, but let the user edit it with a currency symbol and fixed number of decimal places. You can use a writable computed observable to represent the formatted price, mapping incoming values back to the underlying float value:
 
-<live-example params='id: "computed-writable-converter"'></live-example>
+```html
+<div>Enter bid price: <input data-bind="value: formattedPrice"/></div>
+<div>(Raw value: <span data-bind="text: price"></span>)</div>
+```
+
+```javascript
+function MyViewModel() {
+    this.price = ko.observable(25.99);
+
+    this.formattedPrice = ko.pureComputed({
+        read: function () {
+            return '$' + this.price().toFixed(2);
+        },
+        write: function (value) {
+            value = parseFloat(value.replace(/[^\.\d]/g, ""));
+            this.price(isNaN(value) ? 0 : value);
+        },
+        owner: this
+    });
+}
+
+ko.applyBindings(new MyViewModel());
+```
 
 
 Now, whenever the user enters a new price, the text box updates to show it formatted with the currency symbol and two decimal places, no matter what format they entered the value in. This gives a great user experience, because the user sees how the software has understood their data entry as a price. They know they can't enter more than two decimal places, because if they try to, the additional decimal places are removed. Similarly, they can't enter negative values, because the `write` callback strips off any minus sign.
@@ -45,7 +122,33 @@ Example 1 showed how a writable computed observable can effectively *filter* its
 
 Taking this a step further, you could also toggle an `isValid` flag depending on whether the latest input was satisfactory, and display a message in the UI accordingly. There's an easier way of doing validation (explained below), but first consider the following example, which demonstrates the mechanism:
 
-<live-example params='id: "computed-writable-filter"'></live-example>
+```html
+<div>Enter a numeric value: <input data-bind="textInput: attemptedValue"/></div>
+<div class="error" data-bind="visible: !lastInputWasValid()">That's not a number!</div>
+<div>(Accepted value: <span data-bind="text: acceptedNumericValue"></span>)</div>
+```
+
+```javascript
+function MyViewModel() {
+    this.acceptedNumericValue = ko.observable(123);
+    this.lastInputWasValid = ko.observable(true);
+
+    this.attemptedValue = ko.pureComputed({
+        read: this.acceptedNumericValue,
+        write: function (value) {
+            if (isNaN(value))
+                this.lastInputWasValid(false);
+            else {
+                this.lastInputWasValid(true);
+                this.acceptedNumericValue(value);
+            }
+        },
+        owner: this
+    });
+}
+
+ko.applyBindings(new MyViewModel());
+```
 
 
 Now, `acceptedNumericValue` will only ever contain numeric values, and any other values entered will trigger the appearance of a validation message instead of updating `acceptedNumericValue`.

--- a/tko.io/src/content/docs/observables/arraychange.md
+++ b/tko.io/src/content/docs/observables/arraychange.md
@@ -30,4 +30,42 @@ trackable = ko.observable().extend({trackArrayChanges: true});
 ```
 
 
-<live-example params='id: "arraychange"'></live-example>
+```html
+<div>
+    <button data-bind="click: addItem">Add Item</button>
+    <button data-bind="click: removeItem">Remove Last</button>
+</div>
+<h4>Items</h4>
+<ul data-bind="foreach: items">
+    <li data-bind="text: $data"></li>
+</ul>
+<h4>Change Log</h4>
+<ul data-bind="foreach: changes">
+    <li data-bind="text: $data"></li>
+</ul>
+```
+
+```javascript
+function ViewModel() {
+    var self = this;
+    self.items = ko.observableArray(["Alpha", "Beta", "Gamma"]);
+    self.changes = ko.observableArray([]);
+
+    self.items.subscribe(function(changeList) {
+        changeList.forEach(function(change) {
+            var msg = change.status + ': ' + change.value + ' (index ' + change.index + ')';
+            self.changes.push(msg);
+        });
+    }, null, "arrayChange");
+
+    self.addItem = function() {
+        self.items.push("Item " + (self.items().length + 1));
+    };
+
+    self.removeItem = function() {
+        self.items.pop();
+    };
+}
+
+ko.applyBindings(new ViewModel());
+```

--- a/tko.io/src/content/docs/observables/extenders.md
+++ b/tko.io/src/content/docs/observables/extenders.md
@@ -33,7 +33,43 @@ If the `firstName` observable's value was changed to `Ted`, then the console wou
 
 This example creates an extender that forces writes to an observable to be numeric rounded to a configurable level of precision.  In this case, the extender will return a new writeable computed observable that will sit in front of the real observable intercepting writes.
 
-<live-example params='id: "extender-numeric"'></live-example>
+```html
+<p><input data-bind="value: myNumberOne" /> (round to whole number)</p>
+<p><input data-bind="value: myNumberTwo" /> (round to two decimals)</p>
+```
+
+```javascript
+ko.extenders.numeric = function(target, precision) {
+    var result = ko.pureComputed({
+        read: target,
+        write: function(newValue) {
+            var current = target(),
+                roundingMultiplier = Math.pow(10, precision),
+                newValueAsNum = isNaN(newValue) ? 0 : +newValue,
+                valueToWrite = Math.round(newValueAsNum * roundingMultiplier) / roundingMultiplier;
+
+            if (valueToWrite !== current) {
+                target(valueToWrite);
+            } else {
+                if (newValue !== current) {
+                    target.notifySubscribers(valueToWrite);
+                }
+            }
+        }
+    }).extend({ notify: 'always' });
+
+    result(target());
+
+    return result;
+};
+
+function AppViewModel(one, two) {
+    this.myNumberOne = ko.observable(one).extend({ numeric: 0 });
+    this.myNumberTwo = ko.observable(two).extend({ numeric: 2 });
+}
+
+ko.applyBindings(new AppViewModel(221.2234, 123.4525));
+```
 
 Note that for this to automatically erase rejected values from the UI, it's necessary to use `.extend({ notify: 'always' })` on the computed observable. Without this, it's possible for the user to enter an invalid `newValue` that when rounded gives an unchanged `valueToWrite`. Then, since the model value would not be changing, there would be no notification to update the textbox in the UI. Using `{ notify: 'always' }` causes the textbox to refresh (erasing rejected values) even if the computed property has not changed value.
 
@@ -41,7 +77,41 @@ Note that for this to automatically erase rejected values from the UI, it's nece
 
 This example creates an extender that allows an observable to be marked as required. Instead of returning a new object, this extender simply adds additional sub-observables to the existing observable. Since observables are functions, they can actually have their own properties. However, when the view model is converted to JSON, the sub-observables will be dropped and we will simply be left with the value of our actual observable.  This is a nice way to add additional functionality that is only relevant for the UI and does not need to be sent back to the server.
 
-<live-example params='id: "extender-validation"'></live-example>
+```html
+<p data-bind="css: { error: firstName.hasError }">
+    <input data-bind='value: firstName, valueUpdate: "afterkeydown"' />
+    <span data-bind='visible: firstName.hasError, text: firstName.validationMessage'> </span>
+</p>
+<p data-bind="css: { error: lastName.hasError }">
+    <input data-bind='value: lastName, valueUpdate: "afterkeydown"' />
+    <span data-bind='visible: lastName.hasError, text: lastName.validationMessage'> </span>
+</p>
+```
+
+```javascript
+ko.extenders.required = function(target, overrideMessage) {
+    target.hasError = ko.observable();
+    target.validationMessage = ko.observable();
+
+    function validate(newValue) {
+       target.hasError(newValue ? false : true);
+       target.validationMessage(newValue ? "" : overrideMessage || "This field is required");
+    }
+
+    validate(target());
+
+    target.subscribe(validate);
+
+    return target;
+};
+
+function AppViewModel(first, last) {
+    this.firstName = ko.observable(first).extend({ required: "Please enter a first name" });
+    this.lastName = ko.observable(last).extend({ required: "" });
+}
+
+ko.applyBindings(new AppViewModel("Bob", "Smith"));
+```
 
 ### Applying multiple extenders
 

--- a/tko.io/src/content/docs/observables/rateLimit-observable.md
+++ b/tko.io/src/content/docs/observables/rateLimit-observable.md
@@ -64,7 +64,33 @@ In this live example, there's an `instantaneousValue` observable that reacts imm
 
 Try it:
 
-<live-example params='id: "rate-limit"'></live-example>
+```html
+<p>Type stuff here: <input data-bind="textInput: instantaneousValue" /></p>
+<p>Current delayed value: <b data-bind="text: delayedValue"> </b></p>
+
+<div data-bind="visible: loggedValues().length > 0">
+    <h3>Stuff you have typed:</h3>
+    <ul data-bind="foreach: loggedValues">
+        <li data-bind="text: $data"></li>
+    </ul>
+</div>
+```
+
+```javascript
+function AppViewModel() {
+    this.instantaneousValue = ko.observable();
+    this.delayedValue = ko.pureComputed(this.instantaneousValue)
+        .extend({ rateLimit: { method: "notifyWhenChangesStop", timeout: 400 } });
+
+    this.loggedValues = ko.observableArray([]);
+    this.delayedValue.subscribe(function (val) {
+        if (val !== '')
+            this.loggedValues.push(val);
+    }, this);
+}
+
+ko.applyBindings(new AppViewModel());
+```
 
 ### Example 3: Avoiding multiple Ajax requests
 

--- a/tko.io/src/content/docs/observables/throttle-extender.md
+++ b/tko.io/src/content/docs/observables/throttle-extender.md
@@ -49,7 +49,33 @@ In this live example, there's an `instantaneousValue` observable that reacts imm
 
 Try it:
 
-<live-example params='id: "throttle-binding"'></live-example>
+```html
+<p>Type stuff here: <input data-bind='value: instantaneousValue, valueUpdate: "afterkeydown"' /></p>
+<p>Current throttled value: <b data-bind="text: throttledValue"> </b></p>
+
+<div data-bind="visible: loggedValues().length > 0">
+    <h3>Stuff you have typed:</h3>
+    <ul data-bind="foreach: loggedValues">
+        <li data-bind="text: $data"></li>
+    </ul>
+</div>
+```
+
+```javascript
+function AppViewModel() {
+    this.instantaneousValue = ko.observable();
+    this.throttledValue = ko.computed(this.instantaneousValue)
+                            .extend({ throttle: 400 });
+
+    this.loggedValues = ko.observableArray([]);
+    this.throttledValue.subscribe(function (val) {
+        if (val !== '')
+            this.loggedValues.push(val);
+    }, this);
+}
+
+ko.applyBindings(new AppViewModel());
+```
 
 ### Example 3: Avoiding multiple Ajax requests
 


### PR DESCRIPTION
## Summary

- Replaces 33 `<live-example>` placeholder tags across 18 doc pages with inline HTML + JavaScript code blocks sourced from the original knockoutjs.com examples
- Adds "Open in Playground" button support for TSX tab code blocks in the `playground-button` Expressive Code plugin
- Updates agent documentation (`llms.txt`, `agent-guide.md`, `agent-testing.md`) with TSX vs HTML binding syntax differences and testing guidance
- Removes legacy placeholder rendering code from `examples.js`

## Test plan

- [ ] Visit doc pages with examples (click-binding, foreach-binding, text-binding) and verify HTML + JS code blocks render with syntax highlighting
- [ ] Verify TSX/HTML tabs appear on HTML code blocks containing `data-bind=`
- [ ] Verify "Open in Playground" buttons appear on both HTML and TSX tabs
- [ ] Click "Open in Playground" on HTML tab — verify code loads and runs in playground
- [ ] Run `bun run build` (clear `.astro` cache first) — verify no build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended playground functionality to support TSX code blocks alongside HTML and JavaScript
  * Added comprehensive documentation comparing two binding syntaxes: HTML `data-bind` for runtime bindings versus TSX `ko-*` attributes for compile-time expressions

* **Documentation**
  * Replaced legacy example placeholders with explicit, inline code samples throughout binding and component documentation
  * Updated guides with clearer TSX and HTML syntax explanations and new testing procedures for playground links

* **Chores**
  * Removed legacy placeholder system for example rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->