### PR TITLE
[codex] Add reduced debug inspection package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,6 @@ builds/**/meta
 .vscode/extensions.json
 !.vscode/launch.json
 .vscode/settings.json
+.claude/worktrees/
 .playwright-mcp
 .playwright-cli

--- a/packages/debug/Makefile
+++ b/packages/debug/Makefile
@@ -1,0 +1,3 @@
+
+include ../../tools/build.mk
+

--- a/packages/debug/index.ts
+++ b/packages/debug/index.ts
@@ -1,0 +1,2 @@
+export * from './src'
+

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -1,0 +1,49 @@
+{
+  "version": "4.0.0",
+  "name": "@tko/debug",
+  "description": "TKO runtime inspection helpers for debugging bound applications",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/knockout/tko.git"
+  },
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist/"
+  ],
+  "keywords": [
+    "knockout",
+    "tko",
+    "debug",
+    "inspect",
+    "devtools"
+  ],
+  "author": "The Knockout Team",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/knockout/tko/issues"
+  },
+  "homepage": "https://tko.io",
+  "dependencies": {
+    "@tko/bind": "^4.0.0",
+    "@tko/computed": "^4.0.0",
+    "@tko/observable": "^4.0.0",
+    "tslib": "^2.2.0"
+  },
+  "karma": {
+    "frameworks": [
+      "mocha"
+    ]
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://opensource.org/licenses/MIT"
+    }
+  ]
+}
+

--- a/packages/debug/spec/debugBehaviors.ts
+++ b/packages/debug/spec/debugBehaviors.ts
@@ -1,0 +1,121 @@
+import { assert } from 'chai'
+
+import { options, cleanNode } from '@tko/utils'
+
+import { observable } from '@tko/observable'
+import { pureComputed } from '@tko/computed'
+
+import { MultiProvider } from '@tko/provider.multi'
+import { VirtualProvider } from '@tko/provider.virtual'
+import { DataBindProvider } from '@tko/provider.databind'
+
+import { applyBindings } from '@tko/bind'
+
+import { bindings as coreBindings } from '@tko/binding.core'
+
+import { inspectNode, inspectObservable, inspectPath } from '../dist'
+
+describe('@tko/debug', function () {
+  let root: HTMLElement
+
+  beforeEach(function () {
+    root = document.createElement('div')
+    document.body.appendChild(root)
+
+    const provider = new MultiProvider({ providers: [new VirtualProvider(), new DataBindProvider()] })
+    options.bindingProviderInstance = provider
+    provider.bindingHandlers.set(coreBindings)
+    options.onError = function (error) {
+      throw error
+    }
+  })
+
+  afterEach(function () {
+    cleanNode(root)
+    document.body.removeChild(root)
+  })
+
+  it('inspects a bound node and its binding context', function () {
+    root.innerHTML = '<span class="target" data-bind="text: answer"></span>'
+
+    applyBindings({ answer: observable('ready') }, root, function (context) {
+      context.extraFlag = true
+    })
+
+    const target = root.querySelector('.target') as HTMLElement
+    const inspection = inspectNode(target)
+
+    assert.equal(inspection.bound, true)
+    assert.equal(inspection.tagName, 'SPAN')
+    assert.equal(inspection.context?.parentsCount, 0)
+    assert.deepEqual(inspection.context?.aliasKeys, ['extraFlag'])
+    assert.equal(inspection.context?.aliases.extraFlag.kind, 'primitive')
+    assert.equal(inspection.context?.chain.length, 1)
+  })
+
+  it('inspects observables with current value and subscriptions', function () {
+    const message = observable('hello')
+
+    root.innerHTML = '<span data-bind="text: message"></span>'
+    applyBindings({ message }, root)
+
+    const inspection = inspectObservable(message)
+
+    assert.isDefined(inspection)
+    assert.equal(inspection?.kind, 'observable')
+    assert.equal(inspection?.value.kind, 'primitive')
+    assert.equal(inspection?.value.value, 'hello')
+    assert.isAtLeast(inspection?.subscriptions.change ?? 0, 1)
+    assert.equal(inspection?.isWritable, true)
+  })
+
+  it('inspects pure computeds with dependency metadata', function () {
+    const price = observable(3)
+    const doubled = pureComputed(function () {
+      return price() * 2
+    })
+
+    root.innerHTML = '<span data-bind="text: doubled"></span>'
+    applyBindings({ doubled }, root)
+
+    const inspection = inspectObservable(doubled)
+
+    assert.isDefined(inspection)
+    assert.equal(inspection?.kind, 'computed')
+    assert.equal(inspection?.isPureComputed, true)
+    assert.equal(inspection?.dependenciesCount, 1)
+    assert.lengthOf(inspection?.dependencies ?? [], 1)
+  })
+
+  it('does not evaluate sleeping pure computeds during inspection by default', function () {
+    let evaluations = 0
+    const sleeping = pureComputed(function () {
+      evaluations++
+      return 'expensive'
+    })
+
+    const inspection = inspectObservable(sleeping)
+    const pathInspection = inspectPath({ sleeping }, 'sleeping')
+
+    assert.equal(evaluations, 0)
+    assert.equal(inspection?.kind, 'computed')
+    assert.equal(inspection?.value.kind, 'computed')
+    assert.equal(pathInspection.value.kind, 'computed')
+  })
+
+  it('resolves direct view-model paths without evaluating computeds', function () {
+    const message = observable('bridge-ready')
+    const doubled = pureComputed(function () {
+      return 2
+    })
+
+    const messageInspection = inspectPath({ message }, 'message')
+    const computedInspection = inspectPath({ doubled }, 'doubled')
+
+    assert.equal(messageInspection.found, true)
+    assert.equal(messageInspection.observable?.kind, 'observable')
+    assert.equal(messageInspection.observable?.value.value, 'bridge-ready')
+    assert.equal(computedInspection.found, true)
+    assert.equal(computedInspection.value.kind, 'computed')
+  })
+})

--- a/packages/debug/src/index.ts
+++ b/packages/debug/src/index.ts
@@ -1,0 +1,3 @@
+export * from './inspectNode'
+export * from './inspectObservable'
+export * from './preview'

--- a/packages/debug/src/inspectNode.ts
+++ b/packages/debug/src/inspectNode.ts
@@ -1,0 +1,82 @@
+import { contextFor, dataFor } from '@tko/bind'
+
+import type { BindingContext } from '@tko/bind'
+
+import { previewValue, ValuePreview } from './preview'
+
+const contextMetaKeys = new Set([
+  'ko',
+  '$data',
+  '$rawData',
+  '$parent',
+  '$parents',
+  '$root',
+  '$index',
+  '$parentContext',
+  '$component'
+])
+
+export interface BindingContextInspection {
+  aliasKeys: string[]
+  aliases: Record<string, ValuePreview>
+  parentsCount: number
+  root: ValuePreview
+  data: ValuePreview
+  rawData: ValuePreview
+  chain: ValuePreview[]
+}
+
+export interface NodeInspection {
+  bound: boolean
+  nodeType: number
+  nodeName: string
+  tagName?: string
+  textPreview: string
+  data?: ValuePreview
+  context?: BindingContextInspection
+}
+
+function inspectContext(context: BindingContext): BindingContextInspection {
+  const aliases: Record<string, ValuePreview> = {}
+  const aliasKeys = Object.keys(context).filter(key => !contextMetaKeys.has(key))
+
+  for (const key of aliasKeys) {
+    aliases[key] = previewValue((context as any)[key])
+  }
+
+  const chain: ValuePreview[] = []
+  let currentContext: BindingContext | undefined = context
+  while (currentContext) {
+    chain.push(previewValue(currentContext.$data))
+    currentContext = currentContext.$parentContext
+  }
+
+  return {
+    aliasKeys,
+    aliases,
+    parentsCount: context.$parents?.length ?? 0,
+    root: previewValue(context.$root),
+    data: previewValue(context.$data),
+    rawData: previewValue(context.$rawData),
+    chain
+  }
+}
+
+function previewText(node: Node) {
+  const text = node.textContent ?? ''
+  return text.length > 80 ? `${text.slice(0, 77)}...` : text
+}
+
+export function inspectNode(node: Node): NodeInspection {
+  const context = contextFor(node)
+
+  return {
+    bound: Boolean(context),
+    nodeType: node.nodeType,
+    nodeName: node.nodeName,
+    tagName: (node as Element).tagName,
+    textPreview: previewText(node),
+    data: context ? previewValue(dataFor(node)) : undefined,
+    context: context ? inspectContext(context) : undefined
+  }
+}

--- a/packages/debug/src/inspectObservable.ts
+++ b/packages/debug/src/inspectObservable.ts
@@ -1,0 +1,116 @@
+import { isComputed, isPureComputed } from '@tko/computed'
+import { isObservable, isSubscribable, LATEST_VALUE } from '@tko/observable'
+
+import { previewValue, ValuePreview } from './preview'
+
+export interface ObservableInspection {
+  kind: 'observable' | 'computed' | 'subscribable'
+  isComputed: boolean
+  isPureComputed: boolean
+  isObservable: boolean
+  isWritable: boolean
+  isActive?: boolean
+  subscriptions: Record<string, number>
+  dependenciesCount?: number
+  dependencies?: ValuePreview[]
+  value: ValuePreview
+}
+
+export type PathTarget = unknown
+
+export interface PathInspection {
+  found: boolean
+  path: string[]
+  value: ValuePreview
+  observable?: ObservableInspection
+}
+
+function readCurrentValue(target: any) {
+  if (isObservable(target)) {
+    return target[LATEST_VALUE]
+  }
+
+  return target
+}
+
+function listSubscriptions(target: any) {
+  const subscriptions: Record<string, number> = {}
+  const subscriptionMap = target?._subscriptions ?? {}
+
+  for (const key of Object.keys(subscriptionMap)) {
+    subscriptions[key] = subscriptionMap[key]?.length ?? 0
+  }
+
+  return subscriptions
+}
+
+function normalizePath(path: string | string[]) {
+  if (Array.isArray(path)) {
+    return path.filter(Boolean)
+  }
+
+  return path
+    .split('.')
+    .map(segment => segment.trim())
+    .filter(Boolean)
+}
+
+export function inspectObservable(target: unknown): ObservableInspection | undefined {
+  if (!isSubscribable(target)) {
+    return undefined
+  }
+
+  const computed = isComputed(target)
+  const pureComputed = isPureComputed(target)
+
+  return {
+    kind: computed ? 'computed' : isObservable(target) ? 'observable' : 'subscribable',
+    isComputed: computed,
+    isPureComputed: pureComputed,
+    isObservable: isObservable(target),
+    isWritable: Boolean((target as any).isWriteable),
+    isActive: computed ? (target as any).isActive() : undefined,
+    subscriptions: listSubscriptions(target),
+    dependenciesCount: computed ? (target as any).getDependenciesCount() : undefined,
+    dependencies: computed
+      ? (target as any).getDependencies().map((dependency: unknown) => previewValue(dependency))
+      : undefined,
+    value: computed ? previewValue(target) : previewValue(readCurrentValue(target))
+  }
+}
+
+export function inspectPath(source: PathTarget, path: string | string[]): PathInspection {
+  const segments = normalizePath(path)
+  let current = source
+
+  for (const segment of segments) {
+    const container = isObservable(current) ? readCurrentValue(current) : current
+    if (container === null || container === undefined) {
+      return {
+        found: false,
+        path: segments,
+        value: previewValue(undefined),
+        observable: undefined
+      }
+    }
+
+    const isObjectLike = typeof container === 'object' || typeof container === 'function'
+    if (!isObjectLike || !(segment in (container as object))) {
+      return {
+        found: false,
+        path: segments,
+        value: previewValue(undefined),
+        observable: undefined
+      }
+    }
+
+    current = (container as any)[segment]
+  }
+
+  return {
+    found: true,
+    path: segments,
+    value: previewValue(current),
+    observable: inspectObservable(current)
+  }
+}

--- a/packages/debug/src/preview.ts
+++ b/packages/debug/src/preview.ts
@@ -1,0 +1,88 @@
+import { isComputed, isPureComputed } from '@tko/computed'
+import { isObservable, LATEST_VALUE } from '@tko/observable'
+
+export interface ValuePreview {
+  kind:
+    | 'undefined'
+    | 'null'
+    | 'primitive'
+    | 'function'
+    | 'array'
+    | 'object'
+    | 'observable'
+    | 'computed'
+    | 'circular'
+  type?: string
+  value?: string | number | boolean
+  name?: string
+  length?: number
+  constructorName?: string
+  keys?: string[]
+  current?: ValuePreview
+  isPureComputed?: boolean
+}
+
+function previewArray(value: unknown[]): ValuePreview {
+  return {
+    kind: 'array',
+    length: value.length
+  }
+}
+
+function previewObject(value: object): ValuePreview {
+  return {
+    kind: 'object',
+    constructorName: value.constructor?.name,
+    keys: Object.keys(value).slice(0, 8)
+  }
+}
+
+export function previewValue(
+  value: unknown,
+  depth = 0,
+  seen = new Set<unknown>()
+): ValuePreview {
+  if (value === undefined) {
+    return { kind: 'undefined' }
+  }
+
+  if (value === null) {
+    return { kind: 'null' }
+  }
+
+  if (isComputed(value)) {
+    return {
+      kind: 'computed',
+      isPureComputed: isPureComputed(value)
+    }
+  }
+
+  if (isObservable(value)) {
+    return {
+      kind: 'observable',
+      current: depth > 1 ? undefined : previewValue((value as any)[LATEST_VALUE], depth + 1, seen)
+    }
+  }
+
+  const valueType = typeof value
+
+  if (valueType === 'string' || valueType === 'number' || valueType === 'boolean') {
+    return { kind: 'primitive', type: valueType, value: value as string | number | boolean }
+  }
+
+  if (valueType === 'function') {
+    return { kind: 'function', name: (value as Function).name || '(anonymous)' }
+  }
+
+  if (seen.has(value)) {
+    return { kind: 'circular' }
+  }
+
+  seen.add(value)
+
+  if (Array.isArray(value)) {
+    return previewArray(value)
+  }
+
+  return previewObject(value as object)
+}

--- a/plans/tko-mcp-debug.md
+++ b/plans/tko-mcp-debug.md
@@ -1,0 +1,281 @@
+# Plan: TKO Debug Runtime and MCP Bridge
+
+**Goal**: Add a TKO-native debugging surface for live apps and expose it to AI
+agents through MCP, starting with DOM-to-viewmodel inspection and observable
+tracing.
+
+---
+
+## Current State
+
+- TKO already exposes the core runtime primitives needed for inspection:
+  `dataFor(node)`, `contextFor(node)`, binding contexts, observables,
+  subscribables, computeds, and extenders
+- Agent-facing docs already exist in `tko.io/public/agent-guide.md` and
+  `tko.io/public/agent-testing.md`
+- The repo has no dedicated browser debug package and no MCP server package
+- Existing debugging is mostly ad hoc: console access, spec repros, and
+  runtime helpers used directly by humans
+
+## Opportunity
+
+TKO can support a stronger AI and developer workflow than generic browser
+automation alone by exposing framework-aware runtime tools:
+
+- inspect a DOM node and recover the bound view model/context
+- identify which observables and computeds are driving a UI region
+- trace observable writes and notifications
+- explain why a binding resolved to a particular value
+- capture a minimal repro for the playground or a spec
+
+This is especially valuable for:
+
+- debugging incorrect DOM output
+- investigating missing or excessive reactivity
+- understanding binding-context resolution
+- teaching agents how live TKO apps are actually behaving, not just how source
+  code appears to be written
+
+---
+
+## Desired Outcome
+
+Two complementary packages:
+
+### `@tko/debug`
+
+Browser/runtime package that understands TKO internals and exposes safe,
+framework-aware inspection hooks. This package should be reusable outside MCP,
+including in the docs playground, tests, and future browser tooling.
+
+### `@tko/mcp`
+
+Node-side MCP server package that talks to a live page using the debug bridge
+from `@tko/debug` and turns that information into agent tools.
+
+---
+
+## Package Boundaries
+
+### `@tko/debug` responsibilities
+
+- DOM inspection built on `dataFor(node)` and `contextFor(node)`
+- binding-context serialization:
+  `$data`, `$rawData`, `$parent`, `$parents`, `$root`, aliases, context chain
+- observable and computed inspection:
+  current value preview, subscriber counts, dependency counts, active/sleeping
+  state, extender-related flags where available
+- temporary tracing hooks for subscribables and computeds
+- safe serialization and preview helpers for cyclic graphs and large objects
+- optional bridge registration such as `attachDebugBridge(windowLike)`
+
+### `@tko/debug` non-goals
+
+- no MCP transport logic
+- no dependency on browser automation tooling
+- no required production overhead for apps that do not opt in
+- no new runtime dependency for core packages
+
+### `@tko/mcp` responsibilities
+
+- MCP server entrypoint and tool registration
+- connection to a browser session or playground page
+- invoking the `@tko/debug` bridge inside the page
+- validating tool inputs and shaping tool outputs for agents
+- optional helpers that turn inspections into playground repros or spec seeds
+
+### `@tko/mcp` non-goals
+
+- no direct knowledge of internal TKO state without going through
+  `@tko/debug`
+- no duplication of runtime inspection logic
+- no requirement that normal TKO applications ship MCP code
+
+---
+
+## Design Principles
+
+1. Keep the runtime bridge small and explicit.
+   Prefer a narrow, documented debug surface over broad monkeypatching.
+
+2. Make deep tracing opt-in.
+   Basic inspection should be cheap. More expensive instrumentation should be
+   enabled only when requested.
+
+3. Preserve core package stability.
+   The implementation should avoid invasive changes to shared runtime code
+   unless a hook is clearly justified and remains dev-oriented.
+
+4. Prefer reusable debug primitives over MCP-specific hacks.
+   If a capability is useful for the MCP, it is likely also useful for tests,
+   docs, or a browser console workflow.
+
+5. Return agent-friendly summaries, not raw object dumps.
+   Tool output should explain what matters and avoid flooding the agent with
+   cyclic or low-signal data.
+
+---
+
+## Proposed Runtime Surface
+
+Initial `@tko/debug` API:
+
+- `inspectNode(target)`
+  Returns selector/path metadata, `dataFor`, `contextFor`, and a context-chain
+  summary for the target node
+- `inspectObservable(target)`
+  Returns current value preview, subscribable metadata, subscriber counts, and
+  computed dependency information where applicable
+- `traceObservable(target, options)`
+  Attaches temporary instrumentation and returns a trace handle plus events
+- `listBindings(target)`
+  Returns binding/provider details for a bound node where recoverable
+- `attachDebugBridge(globalObject)`
+  Registers a stable bridge such as `globalObject.__TKO_DEBUG__`
+
+Initial bridge methods exposed to MCP:
+
+- `inspectNodeBySelector(selector)`
+- `inspectObservableByPath(selector, path)`
+- `traceObservableByPath(selector, path, options)`
+- `listBindingsBySelector(selector)`
+- `stopTrace(traceId)`
+
+---
+
+## Proposed MCP Tools
+
+Phase 1 tools:
+
+- `inspect_node`
+  Given a selector, return the bound data/context summary for that node
+- `inspect_observable`
+  Given a node selector plus property path, inspect an observable/computed on
+  the bound view model
+- `trace_observable`
+  Given a node selector plus property path, trace changes for a short session
+
+Phase 2 tools:
+
+- `inspect_binding_context`
+- `list_bindings`
+- `explain_computed`
+- `capture_playground_repro`
+
+Future tools if the first phases land well:
+
+- `diff_node_state`
+- `trace_binding_updates`
+- `find_subscription_leaks`
+- `explain_provider_resolution`
+
+---
+
+## Implementation Plan
+
+### Phase 0: Design and constraints
+
+- confirm package names, intended publishability, and workspace placement
+- confirm whether the first version targets only browser pages or also the docs
+  playground
+- document the bridge contract and output-shaping rules before implementation
+- decide whether to keep the bridge public API minimal and mark richer methods
+  as experimental
+
+### Phase 1: `@tko/debug` foundation
+
+- create `packages/debug`
+- implement safe serializers and preview helpers
+- implement node inspection using existing binding-context runtime APIs
+- implement observable/computed inspection using existing subscribable and
+  computed APIs
+- add a small bridge registration helper
+- add focused tests for:
+  - `inspectNode`
+  - context-chain serialization
+  - observable inspection
+  - computed dependency reporting
+
+### Phase 2: opt-in tracing
+
+- add trace session management in `@tko/debug`
+- instrument subscribable notifications in a reversible, scoped way
+- expose start/stop trace APIs
+- add tests covering:
+  - primitive writes
+  - object writes
+  - computed re-evaluation visibility
+  - cleanup after trace stop
+
+### Phase 3: `@tko/mcp` minimal server
+
+- create `packages/mcp`
+- add MCP server bootstrap and tool registration
+- implement a transport to evaluate bridge calls against a live page
+- implement the first three tools:
+  `inspect_node`, `inspect_observable`, `trace_observable`
+- shape outputs for agent readability and constrained token use
+- add server-level tests where practical and smoke tests against a small sample
+  app or playground page
+
+### Phase 4: docs and agent guidance
+
+- document `@tko/debug` usage for app authors and test authors
+- document the MCP tool surface and intended workflows
+- update agent-facing docs to mention when MCP is available vs when direct
+  playground/spec workflows are preferred
+- include security and privacy notes for exposing live app state to tools
+
+### Phase 5: richer inspection
+
+- add binding/provider inspection
+- add computed explanation helpers
+- add repro capture helpers for playground URLs or spec skeletons
+- evaluate whether some helpers belong in docs tooling instead of MCP
+
+---
+
+## Open Questions
+
+- Should `@tko/debug` ship as a public supported package immediately, or begin
+  as experimental?
+- Should the first `@tko/mcp` transport target the local docs playground, a
+  generic browser session, or both?
+- How much binding/provider detail can be recovered without adding new runtime
+  hooks?
+- Do we want trace output to be pull-based, push-based, or both?
+- Should repro capture emit playground payloads, spec code, or offer both
+  formats?
+
+---
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Debug hooks become invasive in core runtime | keep most logic in `@tko/debug`; add only narrowly justified hooks to core packages |
+| Tool output becomes too noisy for agents | design explicit serializers and small summaries first |
+| Tracing introduces accidental behavior changes | keep tracing opt-in, reversible, and covered by focused tests |
+| MCP transport becomes tightly coupled to one browser workflow | isolate transport behind a small adapter layer |
+| Scope grows too quickly | ship Phase 1 and Phase 3 before expanding into provider explanation or leak detection |
+
+---
+
+## Verification
+
+- `@tko/debug` unit/spec coverage for inspection and tracing behavior
+- `@tko/mcp` smoke test proving a live page can be queried for:
+  - bound node data/context
+  - observable metadata
+  - short trace output
+- manual validation against a small playground example and at least one
+  package-level repro fixture
+- docs verification for any new public runtime APIs or agent workflows
+
+## Initial Success Criteria
+
+- an agent can point at a DOM node and recover the relevant `$data` and context
+- an agent can inspect a named observable/computed from a bound view model
+- an agent can trace a short sequence of observable changes without altering
+  app behavior
+- the runtime inspection surface is useful on its own even without MCP


### PR DESCRIPTION
## What changed

This PR adds a reduced first slice of `@tko/debug`.

It introduces a small runtime inspection package with:
- node inspection for bound DOM/context summary
- observable inspection for current value metadata, subscriptions, and computed dependency info
- lightweight preview helpers for safe summarized output
- focused package tests around bound nodes, observables, direct paths, and non-evaluating pure computed inspection

## Why

This keeps the first implementation deliberately small so we can validate the package shape before adding higher-risk bridge or MCP-facing behavior.

## Impact

- no MCP transport yet
- no browser bridge yet
- no context-path resolution layer yet
- small enough to review and extend incrementally

## Validation

- `make test-headless` in `packages/debug`
- result: `5 SUCCESS`
