### PR TITLE
fix: correct propertyChangeFired typo

### DIFF
--- a/packages/binding.core/src/value.ts
+++ b/packages/binding.core/src/value.ts
@@ -12,7 +12,6 @@ export class value extends BindingHandler {
   }
 
   elementValueBeforeEvent: any
-  propertyChangeFired: any
   propertyChangedFired: boolean
   updateFromModel: any
   constructor(...args: [any]) {
@@ -30,7 +29,7 @@ export class value extends BindingHandler {
     if (this.ieAutoCompleteHackNeeded) {
       this.addEventListener('propertyChange', () => (this.propertyChangedFired = true))
       this.addEventListener('focus', () => (this.propertyChangedFired = false))
-      this.addEventListener('blur', () => this.propertyChangeFired && this.valueUpdateHandler())
+      this.addEventListener('blur', () => this.propertyChangedFired && this.valueUpdateHandler())
     }
 
     arrayForEach(this.eventsToCatch, eventName => this.registerEvent(eventName))


### PR DESCRIPTION
This has always been there, and with the TypeScript port, it was also made into a property. Never set `true` and not detected because a IE10 to properly 11 case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with the IE autocomplete workaround where the blur event handler was referencing incorrect internal state, ensuring proper behavior during autocomplete interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->