### PR TITLE
Fixing package.json module paths and remove helpers

### DIFF
--- a/builds/reference/package.json
+++ b/builds/reference/package.json
@@ -34,7 +34,6 @@
   },
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "homepage": "https://tko.io",
@@ -49,8 +48,7 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.mjs"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   },
   "bugs": {
     "url": "https://github.com/knockout/tko/issues"

--- a/packages/bind/package.json
+++ b/packages/bind/package.json
@@ -2,7 +2,7 @@
   "version": "4.0.0",
   "name": "@tko/bind",
   "description": "TKO DOM-Observable Binding",
-  "module": "dist/bind.js",
+  "module": "dist/index.js",
   "dependencies": {
     "@tko/computed": "^4.0.0",
     "@tko/lifecycle": "^4.0.0",
@@ -14,7 +14,6 @@
   },
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "repository": {
@@ -44,7 +43,6 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   }
 }

--- a/packages/binding.component/package.json
+++ b/packages/binding.component/package.json
@@ -2,7 +2,7 @@
   "version": "4.0.0",
   "name": "@tko/binding.component",
   "description": "component: binding for web components",
-  "module": "dist/binding.component.js",
+  "module": "dist/index.js",
   "license": "MIT",
   "dependencies": {
     "@tko/bind": "^4.0.0",
@@ -15,7 +15,6 @@
   },
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "karma": {
@@ -35,8 +34,7 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   },
   "bugs": {
     "url": "https://github.com/knockout/tko/issues"

--- a/packages/binding.core/package.json
+++ b/packages/binding.core/package.json
@@ -2,10 +2,9 @@
   "version": "4.0.0",
   "name": "@tko/binding.core",
   "description": "TKO Core bindings",
-  "module": "dist/binding.core.js",
+  "module": "dist/index.js",
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "repository": {
@@ -45,7 +44,6 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   }
 }

--- a/packages/binding.foreach/package.json
+++ b/packages/binding.foreach/package.json
@@ -2,10 +2,9 @@
   "version": "4.0.0",
   "name": "@tko/binding.foreach",
   "description": "Knockout Foreach Binding",
-  "module": "dist/binding.foreach.js",
+  "module": "dist/index.js",
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "repository": {
@@ -44,7 +43,6 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   }
 }

--- a/packages/binding.if/package.json
+++ b/packages/binding.if/package.json
@@ -2,10 +2,9 @@
   "version": "4.0.0",
   "name": "@tko/binding.if",
   "description": "TKO conditional (if/ifnot/unless/with/else) bindings",
-  "module": "dist/binding.if.js",
+  "module": "dist/index.js",
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "repository": {
@@ -44,7 +43,6 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   }
 }

--- a/packages/binding.template/package.json
+++ b/packages/binding.template/package.json
@@ -2,7 +2,7 @@
   "version": "4.0.0",
   "name": "@tko/binding.template",
   "description": "TKO Template bindings",
-  "module": "dist/binding.template.js",
+  "module": "dist/index.js",
   "files": [
     "dist/",
     "helpers/",

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -27,7 +27,6 @@
   ],
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "exports": {
@@ -35,8 +34,7 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   },
   "karma": {
     "frameworks": [

--- a/packages/computed/package.json
+++ b/packages/computed/package.json
@@ -5,7 +5,6 @@
   "module": "dist/computed.js",
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "dependencies": {
@@ -42,7 +41,6 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   }
 }

--- a/packages/computed/package.json
+++ b/packages/computed/package.json
@@ -2,7 +2,7 @@
   "version": "4.0.0",
   "name": "@tko/computed",
   "description": "TKO Computed Observables",
-  "module": "dist/computed.js",
+  "module": "dist/index.js",
   "files": [
     "dist/",
     "types/"

--- a/packages/filter.punches/package.json
+++ b/packages/filter.punches/package.json
@@ -2,10 +2,9 @@
   "version": "4.0.0",
   "name": "@tko/filter.punches",
   "description": "TKO filters from knockout punches",
-  "module": "dist/filter.punches.js",
+  "module": "dist/index.js",
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "repository": {
@@ -42,7 +41,6 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   }
 }

--- a/packages/lifecycle/package.json
+++ b/packages/lifecycle/package.json
@@ -1,6 +1,6 @@
 {
   "version": "4.0.0",
-  "module": "dist/lifecycle.js",
+  "module": "dist/index.js",
   "dependencies": {
     "@tko/computed": "^4.0.0",
     "@tko/utils": "^4.0.0"
@@ -10,7 +10,6 @@
   },
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "name": "@tko/lifecycle",
@@ -38,8 +37,7 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   },
   "bugs": {
     "url": "https://github.com/knockout/tko/issues"

--- a/packages/observable/package.json
+++ b/packages/observable/package.json
@@ -11,12 +11,10 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   },
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "keywords": [

--- a/packages/provider.attr/package.json
+++ b/packages/provider.attr/package.json
@@ -2,10 +2,9 @@
   "version": "4.0.0",
   "name": "@tko/provider.attr",
   "description": "Link HTML attributes (e.g. ko-handler-name) to binding handlers",
-  "module": "dist/provider.attr.js",
+  "module": "dist/index.js",
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "license": "MIT",
@@ -29,8 +28,7 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   },
   "bugs": {
     "url": "https://github.com/knockout/tko/issues"

--- a/packages/provider.bindingstring/package.json
+++ b/packages/provider.bindingstring/package.json
@@ -2,10 +2,9 @@
   "version": "4.0.0",
   "name": "@tko/provider.bindingstring",
   "description": "Abstract Base Class for providers that parse a binding string",
-  "module": "dist/provider.bindingString.js",
+  "module": "dist/index.js",
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "license": "MIT",
@@ -30,8 +29,7 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   },
   "bugs": {
     "url": "https://github.com/knockout/tko/issues"

--- a/packages/provider.component/package.json
+++ b/packages/provider.component/package.json
@@ -2,10 +2,9 @@
   "version": "4.0.0",
   "name": "@tko/provider.component",
   "description": "Bind custom web components e.g. <custom-binding>",
-  "module": "dist/provider.component.js",
+  "module": "dist/index.js",
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "license": "MIT",
@@ -34,8 +33,7 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   },
   "bugs": {
     "url": "https://github.com/knockout/tko/issues"

--- a/packages/provider.databind/package.json
+++ b/packages/provider.databind/package.json
@@ -2,10 +2,9 @@
   "version": "4.0.0",
   "name": "@tko/provider.databind",
   "description": "Link HTML attributes based on a `data-bind` HTML attribute",
-  "module": "dist/provider.databind.js",
+  "module": "dist/index.js",
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "license": "MIT",
@@ -30,8 +29,7 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   },
   "bugs": {
     "url": "https://github.com/knockout/tko/issues"

--- a/packages/provider.multi/package.json
+++ b/packages/provider.multi/package.json
@@ -2,10 +2,9 @@
   "version": "4.0.0",
   "name": "@tko/provider.multi",
   "description": "Combine multiple other providers into one",
-  "module": "dist/provider.multi.js",
+  "module": "dist/index.js",
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "license": "MIT",
@@ -30,8 +29,7 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   },
   "bugs": {
     "url": "https://github.com/knockout/tko/issues"

--- a/packages/provider.mustache/package.json
+++ b/packages/provider.mustache/package.json
@@ -2,10 +2,9 @@
   "version": "4.0.0",
   "name": "@tko/provider.mustache",
   "description": "Interpolate text/node attributes {{ }}",
-  "module": "dist/provider.mustache.js",
+  "module": "dist/index.js",
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "repository": {
@@ -44,7 +43,6 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   }
 }

--- a/packages/provider.native/package.json
+++ b/packages/provider.native/package.json
@@ -2,10 +2,9 @@
   "version": "4.0.0",
   "name": "@tko/provider.native",
   "description": "Link binding handlers whose value is already attached to the node",
-  "module": "dist/provider.native.js",
+  "module": "dist/index.js",
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "license": "MIT",
@@ -31,8 +30,7 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   },
   "bugs": {
     "url": "https://github.com/knockout/tko/issues"

--- a/packages/provider.virtual/package.json
+++ b/packages/provider.virtual/package.json
@@ -2,10 +2,9 @@
   "version": "4.0.0",
   "name": "@tko/provider.virtual",
   "description": "Binding provider for <!-- ko handler: ... --> virtual elements",
-  "module": "dist/provider.virtual.js",
+  "module": "dist/index.js",
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "author": "The Knockout Team",
@@ -32,8 +31,7 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   },
   "bugs": {
     "url": "https://github.com/knockout/tko/issues"

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -2,10 +2,9 @@
   "version": "4.0.0",
   "name": "@tko/provider",
   "description": "Abstract base class of tko Provider (HTML <-> Data Binding linker)",
-  "module": "dist/provider.js",
+  "module": "dist/index.js",
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "author": "The Knockout Team",
@@ -32,8 +31,7 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   },
   "bugs": {
     "url": "https://github.com/knockout/tko/issues"

--- a/packages/utils.component/package.json
+++ b/packages/utils.component/package.json
@@ -2,10 +2,9 @@
   "version": "4.0.0",
   "name": "@tko/utils.component",
   "description": "Registry and loading utilities for web components",
-  "module": "dist/utils.component.js",
+  "module": "dist/index.js",
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "license": "MIT",
@@ -38,8 +37,7 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   },
   "bugs": {
     "url": "https://github.com/knockout/tko/issues"

--- a/packages/utils.functionrewrite/package.json
+++ b/packages/utils.functionrewrite/package.json
@@ -2,10 +2,9 @@
   "version": "4.0.0",
   "name": "@tko/utils.functionrewrite",
   "description": "Rewrite `function {}` as lambdas (=>)",
-  "module": "dist/utils.functionrewrite.js",
+  "module": "dist/index.js",
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "license": "MIT",
@@ -27,8 +26,7 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   },
   "bugs": {
     "url": "https://github.com/knockout/tko/issues"

--- a/packages/utils.jsx/package.json
+++ b/packages/utils.jsx/package.json
@@ -2,10 +2,9 @@
   "version": "4.0.0",
   "name": "@tko/utils.jsx",
   "description": "TKO JSX Rendering",
-  "module": "dist/utils.jsx.js",
+  "module": "dist/index.js",
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "repository": {
@@ -44,8 +43,7 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   },
   "bugs": {
     "url": "https://github.com/knockout/tko/issues"

--- a/packages/utils.parser/package.json
+++ b/packages/utils.parser/package.json
@@ -2,10 +2,9 @@
   "version": "4.0.0",
   "name": "@tko/utils.parser",
   "description": "Parse the Javascript-like language used in data-bind and other HTML attributes (CSP-safe)",
-  "module": "dist/utils.parser.js",
+  "module": "dist/index.js",
   "files": [
     "dist/",
-    "helpers/",
     "types/"
   ],
   "license": "MIT",
@@ -35,8 +34,7 @@
       "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
-    },
-    "./helpers/*": "./helpers/*"
+    }
   },
   "bugs": {
     "url": "https://github.com/knockout/tko/issues"

--- a/tools/repackage.mjs
+++ b/tools/repackage.mjs
@@ -7,7 +7,10 @@ import fs from 'fs/promises'
 
 const LERNA_CONF = '../../lerna.json'
 
-const packageData = (pkg, version) => ({
+const hasDir = (name) =>
+  fs.access(name).then(() => true, () => false)
+
+const packageData = (pkg, version, hasHelpers) => ({
   version: version,
   ...pkg,
   // Common
@@ -18,11 +21,11 @@ const packageData = (pkg, version) => ({
       require: "./dist/index.cjs",
       import: "./dist/index.js"
     },
-    "./helpers/*": "./helpers/*"
+    ...(hasHelpers && { "./helpers/*": "./helpers/*" })
   },
   files: [
     "dist/",
-    "helpers/",
+    ...(hasHelpers ? ["helpers/"] : []),
     "types/"
   ],
   homepage: "https://tko.io",
@@ -46,7 +49,8 @@ const parse = async n => JSON.parse(await fs.readFile(n, 'utf8'))
 
 const version = (await parse(LERNA_CONF)).version
 const pkg = await parse('package.json')
+const hasHelpers = await hasDir('helpers')
 console.info(`Rewriting package.json: ${pkg.name}.`)
-const data = packageData(pkg, version)
+const data = packageData(pkg, version, hasHelpers)
 fs.writeFile('package.json', JSON.stringify(data, null, 2), 'utf8')
   .catch(console.error)


### PR DESCRIPTION
- Fixing  the repackage script to conditionally include "helpers/" based on its existence.
- Fix the "module" entry in multiple package.json files to point to "dist/index.js" instead of specific binding files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized package ESM entry points to a single index file for all packages.
  * Simplified package exports by removing secondary ./helpers/* subpath mappings.
  * Reduced published package footprint by removing the helpers directory from distributions.
  * Packaging now conditionally includes helpers only when that directory exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->