### PR TITLE
Fix docs build: remove NODE_OPTIONS strip-types flag

### DIFF
--- a/tko.io/package.json
+++ b/tko.io/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "postinstall": "patch-package",
     "prebuild": "node ./scripts/generate-verified-behaviors.mjs && mkdir -p public/lib && cd ../builds/knockout && make browser && cp dist/browser.min.js ../../tko.io/public/lib/ko.js && cd ../reference && make browser && cp dist/browser.min.js ../../tko.io/public/lib/tko.js",
-    "predev": "npm run prebuild",
-    "dev": "ASTRO_TELEMETRY_DISABLED=1 NODE_OPTIONS=--experimental-strip-types astro dev",
-    "build": "ASTRO_TELEMETRY_DISABLED=1 NODE_OPTIONS=--experimental-strip-types astro build --force",
-    "preview": "ASTRO_TELEMETRY_DISABLED=1 NODE_OPTIONS=--experimental-strip-types astro preview",
-    "check": "ASTRO_TELEMETRY_DISABLED=1 NODE_OPTIONS=--experimental-strip-types astro check"
+    "predev": "bun run prebuild",
+    "dev": "ASTRO_TELEMETRY_DISABLED=1 astro dev",
+    "build": "ASTRO_TELEMETRY_DISABLED=1 astro build --force",
+    "preview": "ASTRO_TELEMETRY_DISABLED=1 astro preview",
+    "check": "ASTRO_TELEMETRY_DISABLED=1 astro check"
   },
   "keywords": ["tko", "knockout", "documentation"],
   "author": "",


### PR DESCRIPTION
## Summary

The docs build has been failing because `NODE_OPTIONS=--experimental-strip-types` is not allowed when Bun spawns Node for Astro. Bun handles TypeScript natively — the flag is unnecessary.

Also fixes `predev` to use `bun run` instead of `npm run`.

## Verified locally

- `cd tko.io && bun run build` — succeeds, 57 pages built
- All 5 example pages in `dist/examples/`
- Glossary and agent docs in `dist/agents/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development workflow to use `bun` package manager for build scripts.
  * Removed experimental Node.js configuration flags from development and build processes while maintaining existing telemetry settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->