### PR TITLE
Fix knip findings: unused files, deps, unlisted deps

### DIFF
--- a/builds/knockout/package.json
+++ b/builds/knockout/package.json
@@ -43,14 +43,14 @@
     "@tko/builder": "^4.0.1",
     "@tko/filter.punches": "^4.0.1",
     "@tko/provider.attr": "^4.0.1",
-    "@tko/provider.bindingstring": "^4.0.1",
     "@tko/provider.component": "^4.0.1",
     "@tko/provider.databind": "^4.0.1",
     "@tko/provider.multi": "^4.0.1",
     "@tko/provider.virtual": "^4.0.1",
     "@tko/utils.component": "^4.0.1",
     "@tko/utils.functionrewrite": "^4.0.1",
-    "tslib": "^2.2.0"
+    "tslib": "^2.2.0",
+    "@tko/utils": "^4.0.1"
   },
   "exports": {
     ".": {

--- a/builds/knockout/src/common.ts
+++ b/builds/knockout/src/common.ts
@@ -1,4 +1,0 @@
-/**
- * Without the following the only export is `default`
- */
-module.exports = require('./index').default

--- a/builds/reference/package.json
+++ b/builds/reference/package.json
@@ -17,7 +17,6 @@
     "@tko/builder": "^4.0.1",
     "@tko/filter.punches": "^4.0.1",
     "@tko/provider.attr": "^4.0.1",
-    "@tko/provider.bindingstring": "^4.0.1",
     "@tko/provider.component": "^4.0.1",
     "@tko/provider.databind": "^4.0.1",
     "@tko/provider.multi": "^4.0.1",
@@ -26,7 +25,8 @@
     "@tko/provider.virtual": "^4.0.1",
     "@tko/utils.component": "^4.0.1",
     "@tko/utils.jsx": "^4.0.1",
-    "tslib": "^2.2.0"
+    "tslib": "^2.2.0",
+    "@tko/utils": "^4.0.1"
   },
   "files": [
     "dist/"

--- a/builds/reference/src/common.ts
+++ b/builds/reference/src/common.ts
@@ -1,4 +1,0 @@
-/**
- * Without the following the only export is `default`
- */
-module.exports = require('./index').default

--- a/knip.json
+++ b/knip.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "workspaces": {
     ".": {
-      "entry": ["vitest.config.ts", "tools/build.ts"],
+      "entry": ["tools/build.ts"],
       "project": ["*.ts", "tools/**/*.ts"]
     },
     "packages/*": {
@@ -16,9 +16,7 @@
   },
   "ignoreDependencies": [
     "tslib",
-    "@vitest/browser",
-    "@vitest/browser-playwright",
     "esbuild",
-    "playwright"
+    "@vitest/browser"
   ]
 }

--- a/packages/bind/package.json
+++ b/packages/bind/package.json
@@ -9,7 +9,8 @@
     "@tko/observable": "^4.0.1",
     "@tko/provider": "^4.0.1",
     "@tko/utils": "^4.0.1",
-    "tslib": "^2.2.0"
+    "tslib": "^2.2.0",
+    "@tko/builder": "^4.0.1"
   },
   "peerDependencies": {
     "@tko/binding.foreach": "^4.0.1"

--- a/packages/binding.component/package.json
+++ b/packages/binding.component/package.json
@@ -8,7 +8,6 @@
     "@tko/bind": "^4.0.1",
     "@tko/lifecycle": "^4.0.1",
     "@tko/observable": "^4.0.1",
-    "@tko/provider": "^4.0.1",
     "@tko/provider.native": "^4.0.1",
     "@tko/utils": "^4.0.1",
     "@tko/utils.component": "^4.0.1",

--- a/packages/binding.foreach/package.json
+++ b/packages/binding.foreach/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "@tko/bind": "^4.0.1",
     "@tko/observable": "^4.0.1",
-    "@tko/provider": "^4.0.1",
     "@tko/utils": "^4.0.1",
     "tslib": "^2.2.0"
   },

--- a/packages/binding.if/package.json
+++ b/packages/binding.if/package.json
@@ -23,7 +23,6 @@
   "homepage": "https://tko.io",
   "dependencies": {
     "@tko/bind": "^4.0.1",
-    "@tko/computed": "^4.0.1",
     "@tko/observable": "^4.0.1",
     "@tko/utils": "^4.0.1",
     "tslib": "^2.2.0"

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -12,7 +12,6 @@
     "@tko/bind": "^4.0.1",
     "@tko/binding.template": "^4.0.1",
     "@tko/computed": "^4.0.1",
-    "@tko/filter.punches": "^4.0.1",
     "@tko/lifecycle": "^4.0.1",
     "@tko/observable": "^4.0.1",
     "@tko/provider": "^4.0.1",

--- a/packages/provider.databind/package.json
+++ b/packages/provider.databind/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "dependencies": {
     "@tko/provider.bindingstring": "^4.0.1",
-    "tslib": "^2.2.0"
+    "tslib": "^2.2.0",
+    "@tko/bind": "^4.0.1"
   },
   "homepage": "https://tko.io",
   "licenses": [

--- a/packages/provider.multi/package.json
+++ b/packages/provider.multi/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "dependencies": {
     "@tko/provider": "^4.0.1",
-    "tslib": "^2.2.0"
+    "tslib": "^2.2.0",
+    "@tko/bind": "^4.0.1"
   },
   "homepage": "https://tko.io",
   "licenses": [

--- a/packages/provider.mustache/package.json
+++ b/packages/provider.mustache/package.json
@@ -22,10 +22,8 @@
   },
   "homepage": "https://tko.io",
   "dependencies": {
-    "@tko/binding.template": "^4.0.1",
     "@tko/observable": "^4.0.1",
     "@tko/provider": "^4.0.1",
-    "@tko/utils": "^4.0.1",
     "@tko/utils.parser": "^4.0.1",
     "tslib": "^2.2.0"
   },

--- a/packages/provider.native/package.json
+++ b/packages/provider.native/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "@tko/observable": "^4.0.1",
     "@tko/provider": "^4.0.1",
-    "tslib": "^2.2.0"
+    "tslib": "^2.2.0",
+    "@tko/bind": "^4.0.1"
   },
   "homepage": "https://tko.io",
   "licenses": [

--- a/packages/provider.virtual/package.json
+++ b/packages/provider.virtual/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "@tko/provider.bindingstring": "^4.0.1",
     "@tko/utils": "^4.0.1",
-    "tslib": "^2.2.0"
+    "tslib": "^2.2.0",
+    "@tko/bind": "^4.0.1"
   },
   "homepage": "https://tko.io",
   "licenses": [

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "@tko/observable": "^4.0.1",
     "@tko/utils": "^4.0.1",
-    "tslib": "^2.2.0"
+    "tslib": "^2.2.0",
+    "@tko/bind": "^4.0.1"
   },
   "homepage": "https://tko.io",
   "licenses": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -22,7 +22,9 @@
   },
   "homepage": "https://tko.io",
   "dependencies": {
-    "tslib": "^2.2.0"
+    "tslib": "^2.2.0",
+    "@tko/provider": "^4.0.1",
+    "@tko/builder": "^4.0.1"
   },
   "licenses": [
     {

--- a/tools/template/index.ts
+++ b/tools/template/index.ts
@@ -1,7 +1,0 @@
-/*!
- *  (c) The Knockout.js Team
- *  https://tko.io
- *  License: MIT (https://opensource.org/licenses/MIT)
- */
-export * as default from './src'
-export * from './src'


### PR DESCRIPTION
## Summary

Safe fixes for knip findings — no public API changes.

- Delete 3 unused files (CJS shims, package template)
- Remove 8 unused `@tko/*` dependencies from package.json
- Add 10 unlisted `@tko/*` dependencies to package.json
- Clean up knip config hints
- Add `bun run verify` script (biome + tsc + build + test)
- Add safe-change workflow guidance to AGENTS.md

## Remaining knip findings (needs public API review)

| Category | Count | Notes |
|---|---|---|
| Unused exports | 10 | Functions/classes — may be used by external consumers |
| Unused exported types | 19 | Type-only — may be used by downstream packages |
| Duplicate exports | 2 | Aliases (harmless) |

These will be addressed after reviewing downstream consumer impact.

## Test plan

- [x] `bun run verify` passes (biome + tsc + build + 2679 tests)
- [x] Each commit verified independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)