### PR TITLE
Add .js extensions to ESM dist imports

### DIFF
--- a/.github/workflows/lint-and-typecheck.yml
+++ b/.github/workflows/lint-and-typecheck.yml
@@ -27,5 +27,8 @@ jobs:
       - name: Build (required for tsc)
         run: bun run build
 
+      - name: Verify ESM extensions
+        run: bun run verify:esm
+
       - name: Typecheck
         run: bunx tsc

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Run Build
         run: bun run build
 
+      - name: Verify ESM extensions
+        run: bun run verify:esm
+
       - name: Run tests
         run: bunx vitest run
         env:

--- a/.github/workflows/test-headless.yml
+++ b/.github/workflows/test-headless.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Run Build
         run: bun run build
 
+      - name: Verify ESM extensions
+        run: bun run verify:esm
+
       - name: Run Tests
         run: bunx vitest run
         env:

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "lint": "bunx @biomejs/biome lint .",
     "lint:fix": "bunx @biomejs/biome check --fix .",
     "check": "bunx @biomejs/biome check .",
+    "verify:esm": "bun tools/verify-esm-extensions.ts",
+    "verify": "bunx @biomejs/biome check . && bunx tsc && bun run build && bun run verify:esm && bunx vitest run",
     "clean": "rm -rf packages/*/dist builds/*/dist coverage"
   },
   "bugs": "https://github.com/knockout/tko/issues",

--- a/tools/build.ts
+++ b/tools/build.ts
@@ -59,3 +59,13 @@ if (buildMode !== 'default' && buildMode !== 'browser') {
 }
 
 await Promise.all(queued)
+
+// Fix ESM imports: add .js extensions to relative imports for Node ESM compat
+const distGlob = new Glob('dist/**/*.{js,mjs}')
+for await (const file of distGlob.scan('.')) {
+  const content = await Bun.file(file).text()
+  const fixed = content.replace(/(from\s+['"])(\.\.?\/[^'"]+?)(?<!\.js)(?=['"])/g, '$1$2.js')
+  if (fixed !== content) {
+    await Bun.write(file, fixed)
+  }
+}

--- a/tools/verify-esm-extensions.ts
+++ b/tools/verify-esm-extensions.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env bun
+/**
+ * Verify all relative imports in ESM dist files have .js extensions.
+ * Run after `bun run build` to catch regressions.
+ */
+import { Glob } from 'bun'
+
+const BAD_IMPORT = /from\s+['"]\.\.?\/[^'"]+?(?<!\.js)['"]/g
+
+let failures = 0
+
+for (const pattern of ['packages/*/dist/**/*.{js,mjs}', 'builds/*/dist/**/*.{js,mjs}']) {
+  const glob = new Glob(pattern)
+  for await (const file of glob.scan('.')) {
+    const content = await Bun.file(file).text()
+    const matches = content.match(BAD_IMPORT)
+    if (matches) {
+      for (const m of matches) {
+        console.error(`${file}: extensionless import ${m}`)
+        failures++
+      }
+    }
+  }
+}
+
+if (failures) {
+  console.error(`\n${failures} extensionless ESM import(s) found. Run \`bun run build\` to fix.`)
+  process.exit(1)
+} else {
+  console.log('All ESM dist imports have .js extensions.')
+}


### PR DESCRIPTION
## Summary

Fixes extensionless relative imports in ESM dist output that break Node's strict ESM resolver.

## Problem

esbuild's `--outdir` mode transpiles each `.ts` file individually but preserves extensionless relative imports:

```js
export { Builder } from "./Builder";  // ERR_MODULE_NOT_FOUND in Node ESM
```

This breaks any tool using strict ESM resolution (Node native ESM, vitest, etc.).

## Fix

Post-processing step in `tools/build.ts` that appends `.js` to all relative import specifiers in `dist/**/*.{js,mjs}` files after esbuild runs:

```js
export { Builder } from "./Builder.js";  // works
```

Affects all 24 packages — every ESM dist file now has correct extensions.

## Test plan

- [x] All dist files have `.js` extensions on relative imports (verified via grep)
- [x] `bunx tsc` — 0 errors
- [x] `bunx vitest run` — 2679 tests pass
- [x] `bunx @biomejs/biome check .` — clean

Fixes #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)