### PR TITLE
Enable verbatimModuleSyntax, remove tslib

### DIFF
--- a/builds/knockout/package.json
+++ b/builds/knockout/package.json
@@ -49,7 +49,6 @@
     "@tko/provider.virtual": "^4.0.1",
     "@tko/utils.component": "^4.0.1",
     "@tko/utils.functionrewrite": "^4.0.1",
-    "tslib": "^2.2.0",
     "@tko/utils": "^4.0.1"
   },
   "exports": {

--- a/builds/reference/package.json
+++ b/builds/reference/package.json
@@ -25,7 +25,6 @@
     "@tko/provider.virtual": "^4.0.1",
     "@tko/utils.component": "^4.0.1",
     "@tko/utils.jsx": "^4.0.1",
-    "tslib": "^2.2.0",
     "@tko/utils": "^4.0.1"
   },
   "files": [

--- a/knip.json
+++ b/knip.json
@@ -15,7 +15,6 @@
     }
   },
   "ignoreDependencies": [
-    "tslib",
     "esbuild",
     "@vitest/browser"
   ]

--- a/packages/bind/package.json
+++ b/packages/bind/package.json
@@ -9,7 +9,6 @@
     "@tko/observable": "^4.0.1",
     "@tko/provider": "^4.0.1",
     "@tko/utils": "^4.0.1",
-    "tslib": "^2.2.0",
     "@tko/builder": "^4.0.1"
   },
   "peerDependencies": {

--- a/packages/binding.component/package.json
+++ b/packages/binding.component/package.json
@@ -11,8 +11,7 @@
     "@tko/provider.native": "^4.0.1",
     "@tko/utils": "^4.0.1",
     "@tko/utils.component": "^4.0.1",
-    "@tko/utils.jsx": "^4.0.1",
-    "tslib": "^2.2.0"
+    "@tko/utils.jsx": "^4.0.1"
   },
   "files": [
     "dist/"

--- a/packages/binding.core/package.json
+++ b/packages/binding.core/package.json
@@ -25,8 +25,7 @@
     "@tko/bind": "^4.0.1",
     "@tko/computed": "^4.0.1",
     "@tko/observable": "^4.0.1",
-    "@tko/utils": "^4.0.1",
-    "tslib": "^2.2.0"
+    "@tko/utils": "^4.0.1"
   },
   "licenses": [
     {

--- a/packages/binding.foreach/package.json
+++ b/packages/binding.foreach/package.json
@@ -24,8 +24,7 @@
   "dependencies": {
     "@tko/bind": "^4.0.1",
     "@tko/observable": "^4.0.1",
-    "@tko/utils": "^4.0.1",
-    "tslib": "^2.2.0"
+    "@tko/utils": "^4.0.1"
   },
   "licenses": [
     {

--- a/packages/binding.if/package.json
+++ b/packages/binding.if/package.json
@@ -24,8 +24,7 @@
   "dependencies": {
     "@tko/bind": "^4.0.1",
     "@tko/observable": "^4.0.1",
-    "@tko/utils": "^4.0.1",
-    "tslib": "^2.2.0"
+    "@tko/utils": "^4.0.1"
   },
   "licenses": [
     {

--- a/packages/binding.template/package.json
+++ b/packages/binding.template/package.json
@@ -25,8 +25,7 @@
     "@tko/bind": "^4.0.1",
     "@tko/computed": "^4.0.1",
     "@tko/observable": "^4.0.1",
-    "@tko/utils": "^4.0.1",
-    "tslib": "^2.2.0"
+    "@tko/utils": "^4.0.1"
   },
   "peerDependencies": {
     "@tko/binding.if": "^4.0.1"

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -16,8 +16,7 @@
     "@tko/observable": "^4.0.1",
     "@tko/provider": "^4.0.1",
     "@tko/utils": "^4.0.1",
-    "@tko/utils.parser": "^4.0.1",
-    "tslib": "^2.2.0"
+    "@tko/utils.parser": "^4.0.1"
   },
   "homepage": "https://tko.io",
   "licenses": [

--- a/packages/computed/package.json
+++ b/packages/computed/package.json
@@ -8,8 +8,7 @@
   ],
   "dependencies": {
     "@tko/observable": "^4.0.1",
-    "@tko/utils": "^4.0.1",
-    "tslib": "^2.2.0"
+    "@tko/utils": "^4.0.1"
   },
   "repository": {
     "type": "git",

--- a/packages/filter.punches/package.json
+++ b/packages/filter.punches/package.json
@@ -22,8 +22,7 @@
   },
   "homepage": "https://tko.io",
   "dependencies": {
-    "@tko/observable": "^4.0.1",
-    "tslib": "^2.2.0"
+    "@tko/observable": "^4.0.1"
   },
   "licenses": [
     {

--- a/packages/lifecycle/package.json
+++ b/packages/lifecycle/package.json
@@ -3,8 +3,7 @@
   "module": "dist/index.js",
   "dependencies": {
     "@tko/computed": "^4.0.1",
-    "@tko/utils": "^4.0.1",
-    "tslib": "^2.2.0"
+    "@tko/utils": "^4.0.1"
   },
   "peerDependencies": {
     "@tko/observable": "^4.0.1"

--- a/packages/observable/package.json
+++ b/packages/observable/package.json
@@ -29,8 +29,7 @@
   },
   "homepage": "https://tko.io",
   "dependencies": {
-    "@tko/utils": "^4.0.1",
-    "tslib": "^2.2.0"
+    "@tko/utils": "^4.0.1"
   },
   "licenses": [
     {

--- a/packages/provider.attr/package.json
+++ b/packages/provider.attr/package.json
@@ -8,8 +8,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@tko/provider": "^4.0.1",
-    "tslib": "^2.2.0"
+    "@tko/provider": "^4.0.1"
   },
   "homepage": "https://tko.io",
   "licenses": [

--- a/packages/provider.bindingstring/package.json
+++ b/packages/provider.bindingstring/package.json
@@ -9,8 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "@tko/provider": "^4.0.1",
-    "@tko/utils.parser": "^4.0.1",
-    "tslib": "^2.2.0"
+    "@tko/utils.parser": "^4.0.1"
   },
   "homepage": "https://tko.io",
   "licenses": [

--- a/packages/provider.component/package.json
+++ b/packages/provider.component/package.json
@@ -13,8 +13,7 @@
     "@tko/provider": "^4.0.1",
     "@tko/utils": "^4.0.1",
     "@tko/utils.component": "^4.0.1",
-    "@tko/utils.parser": "^4.0.1",
-    "tslib": "^2.2.0"
+    "@tko/utils.parser": "^4.0.1"
   },
   "homepage": "https://tko.io",
   "licenses": [

--- a/packages/provider.databind/package.json
+++ b/packages/provider.databind/package.json
@@ -9,7 +9,6 @@
   "license": "MIT",
   "dependencies": {
     "@tko/provider.bindingstring": "^4.0.1",
-    "tslib": "^2.2.0",
     "@tko/bind": "^4.0.1"
   },
   "homepage": "https://tko.io",

--- a/packages/provider.multi/package.json
+++ b/packages/provider.multi/package.json
@@ -9,7 +9,6 @@
   "license": "MIT",
   "dependencies": {
     "@tko/provider": "^4.0.1",
-    "tslib": "^2.2.0",
     "@tko/bind": "^4.0.1"
   },
   "homepage": "https://tko.io",

--- a/packages/provider.mustache/package.json
+++ b/packages/provider.mustache/package.json
@@ -24,8 +24,7 @@
   "dependencies": {
     "@tko/observable": "^4.0.1",
     "@tko/provider": "^4.0.1",
-    "@tko/utils.parser": "^4.0.1",
-    "tslib": "^2.2.0"
+    "@tko/utils.parser": "^4.0.1"
   },
   "licenses": [
     {

--- a/packages/provider.native/package.json
+++ b/packages/provider.native/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "@tko/observable": "^4.0.1",
     "@tko/provider": "^4.0.1",
-    "tslib": "^2.2.0",
     "@tko/bind": "^4.0.1"
   },
   "homepage": "https://tko.io",

--- a/packages/provider.virtual/package.json
+++ b/packages/provider.virtual/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@tko/provider.bindingstring": "^4.0.1",
     "@tko/utils": "^4.0.1",
-    "tslib": "^2.2.0",
     "@tko/bind": "^4.0.1"
   },
   "homepage": "https://tko.io",

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@tko/observable": "^4.0.1",
     "@tko/utils": "^4.0.1",
-    "tslib": "^2.2.0",
     "@tko/bind": "^4.0.1"
   },
   "homepage": "https://tko.io",

--- a/packages/utils.component/package.json
+++ b/packages/utils.component/package.json
@@ -10,8 +10,7 @@
   "dependencies": {
     "@tko/lifecycle": "^4.0.1",
     "@tko/observable": "^4.0.1",
-    "@tko/utils": "^4.0.1",
-    "tslib": "^2.2.0"
+    "@tko/utils": "^4.0.1"
   },
   "peerDependencies": {
     "@tko/bind": "^4.0.1",

--- a/packages/utils.functionrewrite/package.json
+++ b/packages/utils.functionrewrite/package.json
@@ -7,9 +7,7 @@
     "dist/"
   ],
   "license": "MIT",
-  "dependencies": {
-    "tslib": "^2.2.0"
-  },
+  "dependencies": {},
   "homepage": "https://tko.io",
   "licenses": [
     {

--- a/packages/utils.jsx/package.json
+++ b/packages/utils.jsx/package.json
@@ -23,8 +23,7 @@
     "@tko/lifecycle": "^4.0.1",
     "@tko/observable": "^4.0.1",
     "@tko/provider.native": "^4.0.1",
-    "@tko/utils": "^4.0.1",
-    "tslib": "^2.2.0"
+    "@tko/utils": "^4.0.1"
   },
   "homepage": "https://tko.io",
   "licenses": [

--- a/packages/utils.parser/package.json
+++ b/packages/utils.parser/package.json
@@ -9,8 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "@tko/observable": "^4.0.1",
-    "@tko/utils": "^4.0.1",
-    "tslib": "^2.2.0"
+    "@tko/utils": "^4.0.1"
   },
   "peerDependencies": {
     "@tko/bind": "^4.0.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -22,7 +22,6 @@
   },
   "homepage": "https://tko.io",
   "dependencies": {
-    "tslib": "^2.2.0",
     "@tko/provider": "^4.0.1",
     "@tko/builder": "^4.0.1"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "module": "es2022",
     "moduleResolution": "bundler",
     "allowJs": false,
-    "importHelpers": true,
+    "verbatimModuleSyntax": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "noEmit": true,


### PR DESCRIPTION
## Summary

- Enable `verbatimModuleSyntax: true` in tsconfig — enforces `import type` at the compiler level
- Remove `importHelpers: true` — no helpers needed with `target: es2022`
- Remove `tslib` from all 27 packages (unused dependency)

Credit: @phillipc ([review comment](https://github.com/knockout/tko/pull/312#issuecomment-4256614972))

## Test plan

- [x] `bunx tsc` — 0 errors
- [x] `bun run build` — all packages build
- [x] `bunx vitest run` — 2690 tests pass
- [x] Biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)