### PR TITLE
Add 'Always Improve' principle to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,19 @@ When validating `tko.io` documentation changes with the local docs site:
 - Treat docs example work as incomplete until the emitted playground payload compiles cleanly on the live site.
 - If a page has multiple TSX examples, check every TSX playground button, not just the first one.
 
+## Always Improve
+
+Leave the codebase a little better than you found it. When you touch a file, fix small nearby issues if they're low-risk and on-scope:
+
+- Typos in comments or docstrings
+- Dead code or unused imports
+- Stale comments referring to renamed or removed APIs
+- A missing test that would have caught the bug you're fixing
+
+When a feedback loop fails, fix the loop — not just the symptom. Examples: `bun run test` passing locally while CI fails, a confusing script error, a flaky assertion that hides real bugs. Fold the missing check into the local command so the next contributor doesn't hit the same wall.
+
+Avoid scope creep. If an improvement would balloon the PR, file a follow-up issue or spawn a separate task instead.
+
 ## Important Guidelines
 
 - Do not modify `tools/build.ts` or `vitest.config.ts` without understanding

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,9 +172,9 @@ When validating `tko.io` documentation changes with the local docs site:
 
 ## Always Improve
 
-Leave the codebase a little better than you found it. When you touch a file, fix small nearby issues if they're low-risk and on-scope:
+Leave the codebase a little better than you found it. When you touch a file, fix small nearby issues if they're low-risk and in-scope:
 
-- Typos in comments or docstrings
+- Typos in comments or JSDoc
 - Dead code or unused imports
 - Stale comments referring to renamed or removed APIs
 - A missing test that would have caught the bug you're fixing


### PR DESCRIPTION
## Summary

Adds a short "Always Improve" section to AGENTS.md codifying two related habits:

1. **Low-risk improvements on files you touch** — typos, dead code, stale comments, tests that would have caught the bug you're fixing.
2. **Fix the feedback loop, not just the symptom** — when local and CI diverge (e.g. tests pass locally but CI fails), fold the missing check into the local command so the next contributor doesn't hit the same wall.

Example of (2) from the current in-flight PR 326: stale `builds/knockout/dist/browser.min.js` meant local tests passed while CI failed. Fix wasn't just updating the spec — it was also making `bun run test` rebuild bundles and run biome, matching CI. Future false negatives in that shape won't recur.

## Test plan

Docs-only change, no code to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)