### PR TITLE
Document TKO's testing coverage bar (real browsers only)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,7 @@ Individual packages can be built from their directory with `bun run build`.
 - **Test files**: `packages/*/spec/**/*.ts`, `builds/*/spec/**/*.js`
 - **Run**: `bunx vitest run` (all tests) or `bunx vitest run <path>` (single file)
 
-Tests run in a real browser via Playwright — not jsdom. This is required
-because TKO does low-level DOM manipulation, MutationObserver, and event handling.
+Real browsers only. No jsdom/happy-dom. TKO binds DOM; partial DOMs diverge exactly where it matters. Don't split runner, exclude specs, or shrink the matrix for speed. Fast local: scope to one package (`bunx vitest run packages/observable`). Why: [#330](https://github.com/knockout/tko/pull/330).
 
 ## Code Style
 


### PR DESCRIPTION
## Summary

Codifies the coverage policy for TKO in AGENTS.md, under the existing **Testing** section. Motivated by the closed [PR #330](https://github.com/knockout/tko/pull/330) — I proposed a happy-dom split for speed, and the trade didn't hold up for a library at TKO's level. Filing the reasoning so future agents don't re-propose the same pattern.

## The policy

TKO is a low-level DOM binding framework published to npm and used by unknown downstream apps. The dark-factory thesis (small teams + AI assistance maintaining a framework) puts the test suite in the role humans used to play. So the coverage bar is higher than typical.

Three concrete rules:

1. **Every spec runs in every supported real browser.** CI matrix (chromium, firefox, webkit) is load-bearing.
2. **No partial-DOM environments.** happy-dom/jsdom/linkedom give false signal for a DOM binding library — the behaviors TKO most needs to verify (form-control event ordering, MutationObserver, namespaced attributes, custom elements) are exactly where partial DOMs diverge.
3. **Excluding files from a run is a red flag.** Concentrates risk; doesn't save coverage.

Also points at PR #330 as a worked example so the rationale is traceable.

## Test plan

Docs-only. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)