### PR TITLE
AGENTS.md: agent context + testing framed as additive coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,17 +10,12 @@ License: MIT
 
 ## Context for every agent
 
-Three things shape every decision here, more than any specific rule:
+Two things shape the coverage/safety bar here more than any specific rule:
 
-1. **Low-level framework.** Observables, computeds, binding engine — infrastructure, not an app. A regression doesn't hit one app; it hits every downstream consumer.
-2. **Unknown, broad audience.** npm-published, used in apps the maintainers will never see — including high-stakes ones (financial services, enterprise, legacy KO bases).
-3. **Dark-factory thesis.** Small teams plus AI agents maintaining what once took a big team. Tests carry the load human review used to.
+- **Low-level framework with an unknown audience.** Observables, computeds, binding engine — infrastructure, not an app. Published to npm and used in apps the maintainers will never see, including high-stakes ones. A regression hits every downstream consumer.
+- **Dark-factory thesis.** Small teams plus AI agents maintaining what once took a big team. Tests carry the load human review used to.
 
-Implications:
-- Coverage bar is higher than typical. Don't trade it for speed.
-- New test environments or targets are **additive**, never replacements.
-- Avoid rules that foreclose future goals (new runtimes, new targets). Framing beats prescription.
-- When in doubt, more signal, not less.
+Together: coverage and signal are expensive to lose and cheap to keep. When a change trades either away, say so explicitly and justify the delta.
 
 ## Project Structure
 
@@ -73,7 +68,7 @@ Individual packages can be built from their directory with `bun run build`.
 - **Test files**: `packages/*/spec/**/*.ts`, `builds/*/spec/**/*.js`
 - **Run**: `bunx vitest run` (all tests) or `bunx vitest run <path>` (single file)
 
-Today the suite runs in a real-browser matrix (chromium, firefox, webkit) — authoritative because the binding layer is exercised against real DOM behavior. Additional environments (happy-dom, node, bun, TUI shims, …) are welcome when they **add** coverage for runtimes TKO should work in. Additive, never replacement; a test failing in a new environment is signal (missing polyfill, real env-scoped behavior, or a test that assumed too much) — fix the signal, don't prune the test.
+Today the suite runs in a real-browser matrix (chromium, firefox, webkit) — authoritative because the binding layer is exercised against real DOM behavior. Additional environments (happy-dom, node, bun, TUI shims, …) should **add** coverage for runtimes TKO should work in; they are not a substitute for the authoritative matrix. If a PR replaces a runner, environment, or matrix target, say so explicitly in the PR and justify the coverage delta. A test failing in a new environment is usually signal (missing polyfill, env-scoped behavior worth documenting, or a test that assumed too much) — investigate before excluding.
 
 Fast local iteration: scope the run (`bunx vitest run packages/observable`, ~1s warm).
 
@@ -200,17 +195,23 @@ Avoid scope creep. If an improvement would balloon the PR, file a follow-up issu
 
 ## Review Your Own Change Adversarially
 
-Before declaring a change done, steelman the case against it. Ask what could go wrong, what assumption could be false, what future goal it quietly forecloses, what coverage or signal it weakens, who it surprises. Then ask what a motivated reviewer would flag — or spawn a subagent to find out.
+Before declaring a change done, steelman the case against it. Ask what could go wrong, what assumption could be false, what future goal it quietly forecloses, what coverage or signal it weakens, who it surprises. Get an independent second pass (a colleague, a subagent where available) on changes that touch framework internals, test coverage, public APIs, or docs the whole team relies on.
 
-Common failure modes worth probing every time:
+This is the ceiling on "Always Improve": that section pushes toward *more* in a PR; this one pushes toward *scrutiny* of what's in it. Use both — improve in scope, audit the scope itself here.
+
+Failure modes specific to a published low-level framework, worth probing every time:
+- Backwards-compat breaks in `@tko/build.knockout` (the legacy surface consumers rely on)
+- Subscription / computed / DOM-listener disposal leaks
+- Perf regressions in hot paths (observable read, dependency tracking, binding apply)
+- Public `@tko/*` API changes shipped without a changeset
+- Import-time side effects that poison the module graph
 - Trading coverage or signal for speed/convenience
-- Optimizing for the happy path and glossing over edge cases
 - Locking in the current shape of the project with presumptive rules
 - Patching the symptom, not the root cause
 - Scope creep disguised as "while I'm here"
 - Silent assumptions about environment, timing, or ordering
 
-If your change doesn't survive a ten-minute attempt to poke holes in it, it's not ready. Spawn a subagent for an independent adversarial pass on PRs that touch framework internals, test coverage, public APIs, or docs the entire team relies on.
+If the change doesn't survive a ten-minute attempt to poke holes in it, it's not ready.
 
 ## Important Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,20 @@ Repository: https://github.com/knockout/tko
 Docs: https://tko.io
 License: MIT
 
+## Context for every agent
+
+Three things shape every decision here, more than any specific rule:
+
+1. **Low-level framework.** Observables, computeds, binding engine — infrastructure, not an app. A regression doesn't hit one app; it hits every downstream consumer.
+2. **Unknown, broad audience.** npm-published, used in apps the maintainers will never see — including high-stakes ones (financial services, enterprise, legacy KO bases).
+3. **Dark-factory thesis.** Small teams plus AI agents maintaining what once took a big team. Tests carry the load human review used to.
+
+Implications:
+- Coverage bar is higher than typical. Don't trade it for speed.
+- New test environments or targets are **additive**, never replacements.
+- Avoid rules that foreclose future goals (new runtimes, new targets). Framing beats prescription.
+- When in doubt, more signal, not less.
+
 ## Project Structure
 
 Monorepo with Bun workspaces.
@@ -59,8 +73,9 @@ Individual packages can be built from their directory with `bun run build`.
 - **Test files**: `packages/*/spec/**/*.ts`, `builds/*/spec/**/*.js`
 - **Run**: `bunx vitest run` (all tests) or `bunx vitest run <path>` (single file)
 
-Tests run in a real browser via Playwright — not jsdom. This is required
-because TKO does low-level DOM manipulation, MutationObserver, and event handling.
+Today the suite runs in a real-browser matrix (chromium, firefox, webkit) — authoritative because the binding layer is exercised against real DOM behavior. Additional environments (happy-dom, node, bun, TUI shims, …) are welcome when they **add** coverage for runtimes TKO should work in. Additive, never replacement; a test failing in a new environment is signal (missing polyfill, real env-scoped behavior, or a test that assumed too much) — fix the signal, don't prune the test.
+
+Fast local iteration: scope the run (`bunx vitest run packages/observable`, ~1s warm).
 
 ## Code Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,20 @@ When a feedback loop fails, fix the loop — not just the symptom. Examples: `bu
 
 Avoid scope creep. If an improvement would balloon the PR, file a follow-up issue or spawn a separate task instead.
 
+## Review Your Own Change Adversarially
+
+Before declaring a change done, steelman the case against it. Ask what could go wrong, what assumption could be false, what future goal it quietly forecloses, what coverage or signal it weakens, who it surprises. Then ask what a motivated reviewer would flag — or spawn a subagent to find out.
+
+Common failure modes worth probing every time:
+- Trading coverage or signal for speed/convenience
+- Optimizing for the happy path and glossing over edge cases
+- Locking in the current shape of the project with presumptive rules
+- Patching the symptom, not the root cause
+- Scope creep disguised as "while I'm here"
+- Silent assumptions about environment, timing, or ordering
+
+If your change doesn't survive a ten-minute attempt to poke holes in it, it's not ready. Spawn a subagent for an independent adversarial pass on PRs that touch framework internals, test coverage, public APIs, or docs the entire team relies on.
+
 ## Important Guidelines
 
 - Do not modify `tools/build.ts` or `vitest.config.ts` without understanding

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,7 @@ Failure modes specific to a published low-level framework, worth probing every t
 - Trading coverage or signal for speed/convenience
 - Locking in the current shape of the project with presumptive rules
 - Patching the symptom, not the root cause
-- Scope creep disguised as "while I'm here"
+- Unrelated refactors or opportunistic redesigns that balloon the PR (the "Always Improve" bar is *small, low-risk, in-scope* fixes — anything larger belongs in its own PR)
 - Silent assumptions about environment, timing, or ordering
 
 If the change doesn't survive a ten-minute attempt to poke holes in it, it's not ready.


### PR DESCRIPTION
## Summary

Two changes to `AGENTS.md`:

### 1. New "Context for every agent" section

Up near the top, before the project structure. Establishes the three framings that shape every decision:

1. **Low-level framework** — infrastructure, not an app; a regression hits every downstream consumer.
2. **Unknown, broad audience** — npm-published, used in apps we'll never see, including high-stakes ones.
3. **Dark-factory thesis** — small teams + AI agents maintaining what once took a big team; tests carry the load human review used to.

With implications: coverage bar higher than typical, new environments are additive not replacements, avoid rules that foreclose future goals.

### 2. Reframe the Testing section

The previous line ("real browsers only") was presumptive and forecloses reasonable future targets like SSR / TUI / node reactive code. New framing: the browser matrix is authoritative today; additional environments are **welcome when they add coverage** for runtimes TKO should work in. A failing test in a new environment is signal — fix the signal, don't prune the test.

## Why

Framing beats prescription at TKO's level. A rule saying "no happy-dom" rules out adding TUI runtime validation later; a framing saying "additive, never replacement" gets the same safety in the present without locking the door on the future. Worked through in closed [#330](https://github.com/knockout/tko/pull/330) (failed speed-for-coverage trade) and [#331](https://github.com/knockout/tko/pull/331) (too prescriptive, closed in favor of this).

## Test plan

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)