### PR TITLE
Fix ko.proxy deleteProperty trap dropping the property key

### DIFF
--- a/.changeset/fix-proxy-delete-property.md
+++ b/.changeset/fix-proxy-delete-property.md
@@ -1,0 +1,18 @@
+---
+"@tko/computed": patch
+---
+
+Fix `ko.proxy` `deleteProperty` trap silently doing nothing
+
+The `deleteProperty` handler on proxies built by `ko.proxy` declared only one
+parameter, named `property`. Per the Proxy spec, the trap is invoked with
+`(target, property)` — so the handler was receiving `target` (the internal
+`function(){}`) in place of the property key, stringifying it, and attempting
+to delete that bogus key. The actual property remained on both the mirror
+observable store and the underlying object, and its tracked observable stayed
+alive.
+
+`delete proxied.foo` now correctly removes `foo` from both the proxy and the
+underlying object and returns `true`. Added a regression test to
+`proxyBehavior.ts` — the bug had been present since `ko.proxy` was introduced
+in 2017 and was untested.

--- a/packages/computed/spec/proxyBehavior.ts
+++ b/packages/computed/spec/proxyBehavior.ts
@@ -106,4 +106,19 @@ describe('Proxy', function () {
     }
     expect(p.x2).to.equal(16)
   })
+
+  it('deletes properties from both the proxy and the underlying object', function () {
+    const x: { a; b? } = { a: 1, b: 2 }
+    const p = proxy(x)
+    expect('b' in p).to.equal(true)
+    expect(x.b).to.equal(2)
+
+    const result = delete p.b
+    expect(result).to.equal(true)
+    expect('b' in p).to.equal(false)
+    expect('b' in x).to.equal(false)
+    // Remaining properties are untouched.
+    expect(p.a).to.equal(1)
+    expect(x.a).to.equal(1)
+  })
 })

--- a/packages/computed/src/proxy.ts
+++ b/packages/computed/src/proxy.ts
@@ -54,7 +54,7 @@ export function proxy(object) {
       object[prop] = value
       return true
     },
-    deleteProperty(property) {
+    deleteProperty(_target, property) {
       delete mirror[property as any]
       return delete object[property as any]
     },


### PR DESCRIPTION
## Summary

The `deleteProperty` trap on proxies built by `ko.proxy` (packages/computed/src/proxy.ts) declared one parameter, named `property`. Per the Proxy spec, the trap is invoked with `(target, property)` — so the handler was receiving the internal `function(){}` target in its one slot, stringifying it, and attempting to `delete mirror[stringifiedTarget]` / `delete object[stringifiedTarget]`. Both are no-ops. The real property key was discarded.

Effect: `delete proxied.foo` silently did nothing. The mirror kept the tracked observable alive, and the underlying object still had `.foo`.

Latent since the original `ko.proxy` commit in 2017. No test exercised `delete` on a proxied object.

## Reproduction (pre-fix, stripped of TKO runtime)

```
before delete: mirror.foo= wrapFoo  object.foo= 1
  trap arg (named "property") is: function function () {}...
  attempting: delete mirror[ function () {} ...]
after delete:  mirror.foo= wrapFoo  object.foo= 1
```

## Fix

One-line: add the missing `_target` positional parameter so `property` receives the real key.

## Credit

Finding surfaced by @phillipc in #297 (round-2 TypeScript review findings, critical issue #1). Verified independently against current main and confirmed. Shipping as a standalone fix so #297's skill-adoption discussion can proceed without this bug blocking it.

## Test plan

- [x] Regression test added to `packages/computed/spec/proxyBehavior.ts` — asserts `delete p.b` removes `b` from both the proxy and the underlying object.
- [x] Test fails on pre-fix code (reverted locally to confirm: assertion `expect('b' in p).to.equal(false)` fails because deleted property remains).
- [x] Full browser suite green: 2699 passed.
- [x] Happy-dom project green for `proxyBehavior.ts`.
- [x] `bunx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where deleting properties on proxied objects did not properly remove them from the underlying storage. Properties would persist on both the proxy and original object. Deletion operations now correctly remove properties and return the expected result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->