### PR TITLE
Configure AI PR reviewers: CodeRabbit primary, Codex secondary, Copilot off

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,32 +2,15 @@
 # Codex (chatgpt-codex-connector) is kept as a secondary, adversarial
 # reviewer for deep reviews on demand. GitHub Copilot auto-review is
 # disabled at the repo level.
-
-# See https://docs.coderabbit.ai/guides/configure-coderabbit for the
-# full schema.
-
-language: "en-US"
-early_access: false
+#
+# Schema: https://docs.coderabbit.ai/guides/configure-coderabbit
+# Anything not set here uses CodeRabbit's default.
 
 reviews:
-  profile: "chill"
-  request_changes_workflow: false
-  high_level_summary: true
   poem: false
-  review_status: true
-  collapse_walkthrough: false
 
-  auto_review:
-    enabled: true
-    drafts: false
-    base_branches:
-      - main
-
-  # TKO-specific context. The architectural carve-outs live in AGENTS.md
-  # and tko.io/public/agents/. Surface them to CodeRabbit so it doesn't
-  # flag them as anti-patterns.
   path_instructions:
-    - path: "packages/**/*.ts"
+    - path: "packages/*/src/**/*.ts"
       instructions: |
         TKO is a TypeScript MVVM framework with intentional architectural
         choices that can look like anti-patterns but are not:
@@ -44,12 +27,9 @@ reviews:
           `defineOption` from @tko/utils inside the owning package; see
           tko.io/public/agents/options.md.
 
-    - path: "packages/**/spec/**/*.ts"
+    - path: "packages/*/spec/**/*.ts"
       instructions: |
         Tests use Mocha-style describe/it with Chai assertions and Sinon
         fake timers/spies. Vitest runs them with globals enabled. Bare
         `it()` and `describe()` are expected; they come from vitest's
         global injection, not a missing import.
-
-chat:
-  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,28 +8,3 @@
 
 reviews:
   poem: false
-
-  path_instructions:
-    - path: "packages/*/src/**/*.ts"
-      instructions: |
-        TKO is a TypeScript MVVM framework with intentional architectural
-        choices that can look like anti-patterns but are not:
-        - Factory-function-as-constructor (`Object.setPrototypeOf`, `.fn`
-          prototype wiring) is the core primitive pattern for observables,
-          computeds, subscribables. Do NOT flag.
-        - Module-level side effects (prototype chain wiring, Symbol
-          registration, defineOption calls) are essential, not a smell.
-        - Pervasive `any` is accepted tech debt — flag only in net-new
-          code where a better type is obvious.
-        - `prefer-const` is off in this repo; `let` for never-reassigned
-          vars is fine.
-        - For runtime options (`ko.options.*`), the pattern is
-          `defineOption` from @tko/utils inside the owning package; see
-          tko.io/public/agents/options.md.
-
-    - path: "packages/*/spec/**/*.ts"
-      instructions: |
-        Tests use Mocha-style describe/it with Chai assertions and Sinon
-        fake timers/spies. Vitest runs them with globals enabled. Bare
-        `it()` and `describe()` are expected; they come from vitest's
-        global injection, not a missing import.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,55 @@
+# CodeRabbit configuration — primary AI reviewer for TKO PRs.
+# Codex (chatgpt-codex-connector) is kept as a secondary, adversarial
+# reviewer for deep reviews on demand. GitHub Copilot auto-review is
+# disabled at the repo level.
+
+# See https://docs.coderabbit.ai/guides/configure-coderabbit for the
+# full schema.
+
+language: "en-US"
+early_access: false
+
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+
+  # TKO-specific context. The architectural carve-outs live in AGENTS.md
+  # and tko.io/public/agents/. Surface them to CodeRabbit so it doesn't
+  # flag them as anti-patterns.
+  path_instructions:
+    - path: "packages/**/*.ts"
+      instructions: |
+        TKO is a TypeScript MVVM framework with intentional architectural
+        choices that can look like anti-patterns but are not:
+        - Factory-function-as-constructor (`Object.setPrototypeOf`, `.fn`
+          prototype wiring) is the core primitive pattern for observables,
+          computeds, subscribables. Do NOT flag.
+        - Module-level side effects (prototype chain wiring, Symbol
+          registration, defineOption calls) are essential, not a smell.
+        - Pervasive `any` is accepted tech debt — flag only in net-new
+          code where a better type is obvious.
+        - `prefer-const` is off in this repo; `let` for never-reassigned
+          vars is fine.
+        - For runtime options (`ko.options.*`), the pattern is
+          `defineOption` from @tko/utils inside the owning package; see
+          tko.io/public/agents/options.md.
+
+    - path: "packages/**/spec/**/*.ts"
+      instructions: |
+        Tests use Mocha-style describe/it with Chai assertions and Sinon
+        fake timers/spies. Vitest runs them with globals enabled. Bare
+        `it()` and `describe()` are expected; they come from vitest's
+        global injection, not a missing import.
+
+chat:
+  auto_reply: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,18 +155,8 @@ existing plans in that directory for format examples.
 
 ## AI PR review
 
-TKO uses AI reviewers in layered roles — see `plans/dark-factory.md` for the
-broader context.
-
-- **CodeRabbit** — primary, auto-reviews every non-draft PR against `main`.
-  Config in `.coderabbit.yaml`. Use `@coderabbitai` commands to re-request
-  or chat.
-- **Codex (chatgpt-codex-connector)** — secondary, adversarial / validation.
-  Triggered on demand for deep reviews or second opinions. Leave the default
-  auto-review on if/when you want convergence confirmation on risky PRs.
-- **GitHub Copilot** — **disabled** at the repo level. It flagged stale and
-  misdirected findings on prior PRs and the signal-to-noise wasn't worth it.
-  Do not re-enable without a specific reason.
+CodeRabbit (primary) + Codex (secondary). Copilot disabled. Config and
+rationale in `.coderabbit.yaml`.
 
 ## Agent-First Documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,21 @@ Significant changes should have a plan file in `plans/` before implementation
 begins. Plans document the context, approach, and verification steps. Review
 existing plans in that directory for format examples.
 
+## AI PR review
+
+TKO uses AI reviewers in layered roles — see `plans/dark-factory.md` for the
+broader context.
+
+- **CodeRabbit** — primary, auto-reviews every non-draft PR against `main`.
+  Config in `.coderabbit.yaml`. Use `@coderabbitai` commands to re-request
+  or chat.
+- **Codex (chatgpt-codex-connector)** — secondary, adversarial / validation.
+  Triggered on demand for deep reviews or second opinions. Leave the default
+  auto-review on if/when you want convergence confirmation on risky PRs.
+- **GitHub Copilot** — **disabled** at the repo level. It flagged stale and
+  misdirected findings on prior PRs and the signal-to-noise wasn't worth it.
+  Do not re-enable without a specific reason.
+
 ## Agent-First Documentation
 
 AI coding agents are first-class citizens of TKO. The docs site serves both


### PR DESCRIPTION
## Summary

Codify the AI PR review arrangement to eliminate duplicate findings and uneven signal across three reviewers. Previous PRs (e.g. [#337](https://github.com/knockout/tko/pull/337)) ran all three on defaults and got near-identical findings on the same bug, with Copilot contributing the most noise.

## Changes

- **`.coderabbit.yaml`** (new, 50 lines) — pins CodeRabbit as primary with:
  - Auto-review on \`main\`, drafts skipped
  - \`profile: chill\`, no poem, review_status on
  - Path-scoped instructions telling it NOT to flag TKO's intentional architectural choices: factory-function-as-constructor, \`Object.setPrototypeOf\`, module-level side effects, pervasive \`any\` as accepted tech debt, \`defineOption\` pattern
  - Spec-path instructions about Vitest globals + Mocha/Chai/Sinon
- **AGENTS.md** — new "AI PR review" section documenting the three-tier arrangement and the reasoning behind it.

## Not in this PR (UI-only toggles)

Two settings live in GitHub UI and can't be committed:

1. **Disable Copilot auto-review** — repo Settings → Code review, or remove \`github-copilot[bot]\` from reviewer auto-assignment. Its #337 contributions were stale (O(n²) \`shift\` — already fixed) or misdirected (environment gating — explicitly rejected).
2. **Confirm Codex connector behavior** — leave its auto-review on for now (convergence confirmation is genuinely useful). Revisit if it starts producing noise.

I'll do these two UI steps after this PR merges.

## Why this arrangement

- **CodeRabbit primary**: scripted execution + cross-referencing of coding guidelines + thorough analysis produced the highest signal on #337. Worth having as default-on.
- **Codex secondary**: catches things CodeRabbit misses and vice versa. Convergence between the two = high-confidence real finding.
- **Copilot off**: net-negative on #337 (2/3 findings were bad). Re-enable when there's a specific reason.

## Test plan

- [x] \`.coderabbit.yaml\` validates as YAML (no syntax errors)
- [x] AGENTS.md renders cleanly (section fits in with surrounding structure)
- [ ] First PR opened after merge: verify only CodeRabbit + Codex post reviews
- [ ] CodeRabbit respects the TKO \`path_instructions\` — no false positives on factory-function patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development workflow configuration and documentation to improve code review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->