### PR TITLE
Fix jQuery reference in style update function

### DIFF
--- a/packages/binding.core/src/style.ts
+++ b/packages/binding.core/src/style.ts
@@ -14,7 +14,7 @@ export const style = {
       }
 
       if (options.jQuery) {
-        jQuery(element).css(styleName, styleValue)
+        options.jQuery(element).css(styleName, styleValue)
       } else {
         styleName = styleName.replace(/-(\w)/g, (all, letter) => letter.toUpperCase())
         const previousStyle = element.style[styleName]


### PR DESCRIPTION
**Style binding references global jQuery instead of options.jQuery**

Issue: Guards with options.jQuery but calls bare global jQuery(element). In module environments where jQuery is not a global, this throws ReferenceError.

Detected in https://github.com/knockout/tko/pull/297

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved style update functionality reliability by adjusting how jQuery is referenced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->