### PR TITLE
Refactor string manipulation methods from substr to substring

### DIFF
--- a/packages/binding.core/src/attr.ts
+++ b/packages/binding.core/src/attr.ts
@@ -12,7 +12,7 @@ export const attr = {
 
       // Find the namespace of this attribute, if any.
       const prefixLen = attrName.indexOf(':')
-      const namespace = prefixLen > 0 && element.lookupNamespaceURI(attrName.substr(0, prefixLen))
+      const namespace = prefixLen > 0 && element.lookupNamespaceURI(attrName.substring(0, prefixLen))
 
       // To cover cases like "attr: { checked:someProp }", we want to remove the attribute entirely
       // when someProp is a "no value"-like value (strictly null, false, or undefined)

--- a/packages/filter.punches/src/index.ts
+++ b/packages/filter.punches/src/index.ts
@@ -51,10 +51,10 @@ const filters: Filters = {
           return replacement + value.slice(-length)
         case 'middle': {
           const leftLen = Math.ceil(length / 2)
-          return value.substr(0, leftLen) + replacement + value.slice(leftLen - length)
+          return value.substring(0, leftLen) + replacement + value.slice(leftLen - length)
         }
         default:
-          return value.substr(0, length) + replacement
+          return value.substring(0, length) + replacement
       }
     } else {
       return value

--- a/packages/utils.parser/src/preparse.ts
+++ b/packages/utils.parser/src/preparse.ts
@@ -91,7 +91,7 @@ export default function parseObjectLiteral(objectLiteralString) {
       const match = toks[i - 1].match(divisionLookBehind)
       if (match && !keywordRegexLookBehind[match[0]]) {
         // The slash is actually a division punctuator; re-parse the remainder of the string (not including the slash)
-        str = str.substr(str.indexOf(tok) + 1)
+        str = str.substring(str.indexOf(tok) + 1)
         toks = str.match(bindingToken)
         i = -1
         // Continue with just the slash


### PR DESCRIPTION
Replace deprecated `.substr()` with `.substring()`

Detected in https://github.com/knockout/tko/pull/297