### PR TITLE
Replace hardcoded MAX_LIST_SIZE with Number.MAX_SAFE_INTEGER

### DIFF
--- a/packages/binding.foreach/src/foreach.ts
+++ b/packages/binding.foreach/src/foreach.ts
@@ -24,7 +24,7 @@ import { contextFor, applyBindingsToDescendants, AsyncBindingHandler } from '@tk
 import type { AllBindings } from '@tko/bind'
 
 //      Utilities
-const MAX_LIST_SIZE = 9007199254740991
+const MAX_LIST_SIZE = Number.MAX_SAFE_INTEGER
 
 // from https://github.com/jonschlinkert/is-plain-object
 function isPlainObject(o): o is Record<string, any> {


### PR DESCRIPTION
Use MAX_SAFE_INTEGER instead of a magic number