### PR TITLE
Fix operator precedence values to match MDN specification

### DIFF
--- a/packages/utils.parser/src/operators.ts
+++ b/packages/utils.parser/src/operators.ts
@@ -29,22 +29,22 @@ export interface Operators {
 function looseEqual(a, b) {
   return a == b
 }
-looseEqual.precedence = 10
+looseEqual.precedence = 8
 
 function looseNotEqual(a, b) {
   return a != b
 }
-looseNotEqual.precedence = 10
+looseNotEqual.precedence = 8
 
 function strictEqual(a, b) {
   return a === b
 }
-strictEqual.precedence = 10
+strictEqual.precedence = 8
 
 function strictNotEqual(a, b) {
   return a !== b
 }
-strictNotEqual.precedence = 10
+strictNotEqual.precedence = 8
 
 const operators: Operators = {
   // unary
@@ -157,68 +157,75 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Oper
 operators['@'].precedence = 21
 operators['#'].precedence = 21
 
-// Member
-operators['.'].precedence = 19
-operators['['].precedence = 19
-operators['?.'].precedence = 19
+// Member access and call
+operators['.'].precedence = 17
+operators['['].precedence = 17
+operators['?.'].precedence = 17
 
-// Logical not
-operators['!'].precedence = 16
-operators['!!'].precedence = 16 // explicit double-negative
+// Prefix operators
+operators['!'].precedence = 14
+operators['!!'].precedence = 14 // explicit double-negative
 
 // Prefix inc/dec
-operators['++'].precedence = 16
-operators['--'].precedence = 16
-operators['&-'].precedence = 16
+operators['++'].precedence = 14
+operators['--'].precedence = 14
+operators['&-'].precedence = 14
 
-// exponent
-operators['**'].precedence = 15
+// Exponentiation
+operators['**'].precedence = 13
 
-// mul/div/remainder
-operators['%'].precedence = 14
-operators['*'].precedence = 14
-operators['/'].precedence = 14
+// Multiplicative
+operators['%'].precedence = 12
+operators['*'].precedence = 12
+operators['/'].precedence = 12
 
-// add/sub
-operators['+'].precedence = 13
-operators['-'].precedence = 13
+// Additive
+operators['+'].precedence = 11
+operators['-'].precedence = 11
 
-// bitwise
-operators['|'].precedence = 12
-operators['^'].precedence = 11
-operators['&'].precedence = 10
+// Relational
+operators['<'].precedence = 9
+operators['<='].precedence = 9
+operators['>'].precedence = 9
+operators['>='].precedence = 9
 
-// comparison
-operators['<'].precedence = 11
-operators['<='].precedence = 11
-operators['>'].precedence = 11
-operators['>='].precedence = 11
+// operators['in'].precedence = 9;
+// operators['instanceof'].precedence = 9;
 
-// operators['in'].precedence = 8;
-// operators['instanceof'].precedence = 8;
-// equality
-operators['=='].precedence = 10
-operators['!='].precedence = 10
-operators['==='].precedence = 10
-operators['!=='].precedence = 10
+// Equality
+operators['=='].precedence = 8
+operators['!='].precedence = 8
+operators['==='].precedence = 8
+operators['!=='].precedence = 8
 
-// logic
-operators['&&'].precedence = 6
-operators['||'].precedence = 5
-operators['??'].precedence = 5
+// Bitwise AND
+operators['&'].precedence = 7
+
+// Bitwise XOR
+operators['^'].precedence = 6
+
+// Bitwise OR
+operators['|'].precedence = 5
+
+// Logical AND
+operators['&&'].precedence = 4
+
+// Logical OR / Nullish coalescing
+operators['||'].precedence = 3
+operators['??'].precedence = 3
 
 operators['&&'].earlyOut = a => !a
 operators['||'].earlyOut = a => a
 operators['??'].earlyOut = a => a
 
-// multiple values
-operators[','].precedence = 2
+// Assignment and miscellaneous (lamda)
+operators['=>'].precedence = 2
+
+// Comma, multiple values
+operators[','].precedence = 1
 
 // Call a function
 operators['call'].precedence = 1
-
-// lambda
-operators['=>'].precedence = 1
 
 // Extend the Options type so ko.options.strictEquality is strongly typed
 declare module '@tko/utils' {


### PR DESCRIPTION
## Summary

Corrects operator precedence values in `packages/utils.parser/src/operators.ts` to match the [MDN Operator Precedence table](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_precedence#table).

## What changed

The precedence constants were using an outdated numbering that diverged from MDN's current 18→1 scale. Key fixes:

- **Bitwise operators were in reversed order**: `|` (12) > `^` (11) > `&` (10) — now correctly `&` (7) > `^` (6) > `|` (5)
- **Relational/equality operators overlapped with bitwise**: comparison and bitwise shared precedence levels 10–11 — now properly separated (relational 9, equality 8, bitwise 7/6/5)
- **All values shifted to match MDN's scale**: member access 19→17, prefix 16→14, exponent 15→13, multiplicative 14→12, additive 13→11, logical AND 6→4, logical OR 5→3, arrow 1→2, comma 2→1
- **Function-level equality operators** (`looseEqual`, etc.) updated from precedence 10 to 8

## Verification

All 404 parser tests pass. Full suite (5371 tests) passes.