### PR TITLE
Fix ?? (nullish coalescing) earlyOut to not short-circuit on falsy values

### DIFF
--- a/packages/utils.parser/spec/nodeBehaviors.ts
+++ b/packages/utils.parser/spec/nodeBehaviors.ts
@@ -54,7 +54,10 @@ describe('Operators', function () {
 
   it('?? evaluates rhs iff lhs is null/undefined', () => {
     let rhsCalls = 0
-    const rhs = () => { rhsCalls++; return 'right' }
+    const rhs = () => {
+      rhsCalls++
+      return 'right'
+    }
     const parser = new Parser(null)
     const args = new Arguments(null, [])
 
@@ -67,11 +70,7 @@ describe('Operators', function () {
     ] as const) {
       rhsCalls = 0
       const context = ctxStub({ a: lhs, rhs })
-      const root = nodes_to_tree([
-        new Identifier(parser, 'a'),
-        op['??'],
-        new Identifier(parser, 'rhs', [args])
-      ])
+      const root = nodes_to_tree([new Identifier(parser, 'a'), op['??'], new Identifier(parser, 'rhs', [args])])
       assert.strictEqual(root.get_value(null, context), expected, `${String(lhs)} ?? rhs() value`)
       assert.strictEqual(rhsCalls, expectedCalls, `${String(lhs)} ?? rhs() calls`)
     }

--- a/packages/utils.parser/spec/nodeBehaviors.ts
+++ b/packages/utils.parser/spec/nodeBehaviors.ts
@@ -52,6 +52,31 @@ describe('Operators', function () {
     test([null, op['??'], false], false)
   })
 
+  it('?? evaluates rhs iff lhs is null/undefined', () => {
+    let rhsCalls = 0
+    const rhs = () => { rhsCalls++; return 'right' }
+    const parser = new Parser(null)
+    const args = new Arguments(null, [])
+
+    for (const [lhs, expected, expectedCalls] of [
+      [0, 0, 0],
+      ['', '', 0],
+      [false, false, 0],
+      [null, 'right', 1],
+      [undefined, 'right', 1]
+    ] as const) {
+      rhsCalls = 0
+      const context = ctxStub({ a: lhs, rhs })
+      const root = nodes_to_tree([
+        new Identifier(parser, 'a'),
+        op['??'],
+        new Identifier(parser, 'rhs', [args])
+      ])
+      assert.strictEqual(root.get_value(null, context), expected, `${String(lhs)} ?? rhs() value`)
+      assert.strictEqual(rhsCalls, expectedCalls, `${String(lhs)} ?? rhs() calls`)
+    }
+  })
+
   it('performs ?. optional chaining', () => {
     test([{}, op['?.'], 'a'], undefined)
     test([null, op['?.'], 'a'], undefined)

--- a/packages/utils.parser/spec/nodeBehaviors.ts
+++ b/packages/utils.parser/spec/nodeBehaviors.ts
@@ -58,7 +58,7 @@ describe('Operators', function () {
       rhsCalls++
       return 'right'
     }
-    const parser = new Parser(null)
+    const parser = new Parser()
     const args = new Arguments(null, [])
 
     for (const [lhs, expected, expectedCalls] of [

--- a/packages/utils.parser/src/operators.ts
+++ b/packages/utils.parser/src/operators.ts
@@ -216,7 +216,7 @@ operators['??'].precedence = 3
 
 operators['&&'].earlyOut = a => !a
 operators['||'].earlyOut = a => a
-operators['??'].earlyOut = a => a
+operators['??'].earlyOut = a => a !== null && a !== undefined
 
 // Assignment and miscellaneous (lamda)
 operators['=>'].precedence = 2


### PR DESCRIPTION
## Summary

The `??` operator's `earlyOut` was `a => a`, identical to `||`. This caused `??` to short-circuit on falsy values like `0`, `''`, and `false`, which is incorrect — `??` should only short-circuit when the value is not `null` and not `undefined`.

Detected in https://github.com/knockout/tko/pull/297

## Fix

```diff
-operators['??'].earlyOut = a => a
+operators['??'].earlyOut = a => a !== null && a !== undefined
```

## Verification

All 404 parser tests pass. Full suite (5371 tests) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nullish coalescing operator behavior to correctly handle `null` and `undefined` values separately from other falsy values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->