### PR TITLE
Remove duplicate options import in computed.ts

### DIFF
--- a/packages/computed/src/computed.ts
+++ b/packages/computed/src/computed.ts
@@ -8,7 +8,6 @@ import {
   arrayForEach,
   domNodeIsAttachedToDocument,
   extend,
-  options,
   hasOwnProperty,
   objectForEach,
   options as koOptions,
@@ -427,7 +426,7 @@ computed.fn = {
       }
 
       state.latestValue = newValue
-      if (options.debug) {
+      if (koOptions.debug) {
         this._latestValue = newValue
       }
 


### PR DESCRIPTION
## Summary

Removes the duplicate `options` import from `packages/computed/src/computed.ts`. The module was importing both `options` and `options as koOptions` from `@tko/utils`. The bare `options` reference at line 430 is replaced with the existing `koOptions` alias.

Detected in https://github.com/knockout/tko/pull/297

## Verification

Full test suite passes (5371 tests).