### PR TITLE
Fix makeTemplateNode bypassing HTML sanitization

### DIFF
--- a/.changeset/fix-foreach-script-template-sanitization.md
+++ b/.changeset/fix-foreach-script-template-sanitization.md
@@ -1,0 +1,8 @@
+---
+'@tko/binding.foreach': patch
+---
+
+Fix `makeTemplateNode` bypassing HTML sanitization for `<script>` foreach templates. Script-template text now
+goes through the existing HTML template parsing safeguards, so oversized templates, disallowed nested `<script>`
+markup, and `sanitizeHtmlTemplate` apply consistently. Existing apps that intentionally embed `<script>` markup
+in foreach script templates should set `allowScriptTagsInTemplates: true`.

--- a/packages/binding.foreach/spec/eachBehavior.ts
+++ b/packages/binding.foreach/spec/eachBehavior.ts
@@ -176,6 +176,67 @@ describe('each binding', function () {
     $template.remove()
   })
 
+  it('applies the template size limit to named <script> templates', function () {
+    const originalTemplateSizeLimit = options.templateSizeLimit
+    const target = $('<ul data-bind=\'foreach: {name: "tID", data: $data}\'>Zee</ul>')
+    const $template = $("<script type='text/ko-template' id='tID'></script>").appendTo(document.body)
+    $template.text('<li data-bind="text: $data"></li>')
+
+    try {
+      options.templateSizeLimit = 10
+
+      assert.throws(function () {
+        applyBindings(['G1'], target[0])
+      }, /Template is too long/)
+    } finally {
+      options.templateSizeLimit = originalTemplateSizeLimit
+      $template.remove()
+    }
+  })
+
+  it('rejects nested script markup in named <script> templates when disallowed', function () {
+    const originalAllowScriptTagsInTemplates = options.allowScriptTagsInTemplates
+    const target = $('<ul data-bind=\'foreach: {name: "tID", data: $data}\'>Zee</ul>')
+    const $template = $("<script type='text/ko-template' id='tID'></script>").appendTo(document.body)
+    $template.text('<li data-bind="text: $data"></li><script>alert(1)</script>')
+
+    try {
+      options.allowScriptTagsInTemplates = false
+
+      assert.throws(function () {
+        applyBindings(['G1'], target[0])
+      }, /Script-tag in template detected/)
+    } finally {
+      options.allowScriptTagsInTemplates = originalAllowScriptTagsInTemplates
+      $template.remove()
+    }
+  })
+
+  it('sanitizes named <script> templates before rendering', function () {
+    const originalSanitizeHtmlTemplate = options.sanitizeHtmlTemplate
+    const target = $('<ul data-bind=\'foreach: {name: "tID", data: $data}\'>Zee</ul>')
+    const $template = $("<script type='text/ko-template' id='tID'></script>").appendTo(document.body)
+    const list = ['G1']
+    let sanitizedHtml = ''
+    $template.text('<li data-bind="text: $data"></li>')
+
+    try {
+      options.sanitizeHtmlTemplate = function (html: string) {
+        sanitizedHtml = html
+        return html.replace('<li ', '<li class="sanitized" ')
+      }
+
+      applyBindings(list, target[0])
+
+      assert.include(sanitizedHtml, 'text: $data')
+      assert.equal(target.find('li.sanitized').length, 1)
+      assert.equal(target.text(), 'G1')
+    } finally {
+      options.sanitizeHtmlTemplate = originalSanitizeHtmlTemplate
+      $template.remove()
+    }
+  })
+
   it('uses the name/id of a <div>', function () {
     const target = $('<ul data-bind=\'foreach: {name: "tID2", data: $data}\'>Zee</ul>')
     const list = ['H1', 'H2']

--- a/packages/binding.foreach/src/foreach.ts
+++ b/packages/binding.foreach/src/foreach.ts
@@ -5,7 +5,15 @@
 // Employing sound techniques to make a faster Knockout foreach binding.
 // --------
 
-import { arrayForEach, cleanNode, options, virtualElements, domData, domNodeIsContainedBy } from '@tko/utils'
+import {
+  arrayForEach,
+  cleanNode,
+  options,
+  virtualElements,
+  domData,
+  domNodeIsContainedBy,
+  validateHTMLInput
+} from '@tko/utils'
 
 import { isObservable, unwrap, observable } from '@tko/observable'
 
@@ -57,7 +65,7 @@ function makeTemplateNode(sourceNode) {
     parentNode = sourceNode.content
   } else if (sourceNode.tagName === 'SCRIPT') {
     parentNode = document.createElement('div')
-    parentNode.innerHTML = sourceNode.text
+    parentNode.innerHTML = validateHTMLInput(sourceNode.text)
   } else {
     // Anything else e.g. <div>
     parentNode = sourceNode

--- a/packages/binding.foreach/src/foreach.ts
+++ b/packages/binding.foreach/src/foreach.ts
@@ -12,7 +12,7 @@ import {
   virtualElements,
   domData,
   domNodeIsContainedBy,
-  validateHTMLInput
+  parseHtmlForTemplateNodes
 } from '@tko/utils'
 
 import { isObservable, unwrap, observable } from '@tko/observable'
@@ -20,8 +20,6 @@ import { isObservable, unwrap, observable } from '@tko/observable'
 import type { ObservableArray } from '@tko/observable'
 
 import { contextFor, applyBindingsToDescendants, AsyncBindingHandler } from '@tko/bind'
-
-import type { AllBindings } from '@tko/bind'
 
 //      Utilities
 const MAX_LIST_SIZE = Number.MAX_SAFE_INTEGER
@@ -64,8 +62,7 @@ function makeTemplateNode(sourceNode) {
     // For e.g. <template> tags
     parentNode = sourceNode.content
   } else if (sourceNode.tagName === 'SCRIPT') {
-    parentNode = document.createElement('div')
-    parentNode.innerHTML = validateHTMLInput(sourceNode.text)
+    parentNode = parseHtmlForTemplateNodes(sourceNode.text, sourceNode.ownerDocument)
   } else {
     // Anything else e.g. <div>
     parentNode = sourceNode

--- a/packages/utils/src/dom/html.ts
+++ b/packages/utils/src/dom/html.ts
@@ -68,7 +68,7 @@ export function parseHtmlFragment(html: string, documentContext?: Document): Nod
 }
 
 const scriptTagPattern = /<script\b[^>]*>([\s\S]*?)<\/script[^>]*>/i
-function validateHTMLInput(html: string): string {
+export function validateHTMLInput(html: string): string {
   if (!html) return ''
 
   if (options.templateSizeLimit > 0 && html.length > options.templateSizeLimit) {

--- a/packages/utils/src/dom/html.ts
+++ b/packages/utils/src/dom/html.ts
@@ -68,7 +68,7 @@ export function parseHtmlFragment(html: string, documentContext?: Document): Nod
 }
 
 const scriptTagPattern = /<script\b[^>]*>([\s\S]*?)<\/script[^>]*>/i
-export function validateHTMLInput(html: string): string {
+function validateHTMLInput(html: string): string {
   if (!html) return ''
 
   if (options.templateSizeLimit > 0 && html.length > options.templateSizeLimit) {


### PR DESCRIPTION
## Problem

`makeTemplateNode` in `packages/binding.foreach/src/foreach.ts` assigned `sourceNode.text` directly to `parentNode.innerHTML` for `<script>` template elements, bypassing all three HTML sanitization controls:

- `options.templateSizeLimit`
- `options.allowScriptTagsInTemplates`
- `options.sanitizeHtmlTemplate`

- Detected in https://github.com/knockout/tko/pull/350

## Fix

- Export `validateHTMLInput` from `@tko/utils` (was previously internal to `html.ts`)
- Route the `<script>` element's `.text` through `validateHTMLInput()` before assigning to `innerHTML`

This ensures the same size-limit, script-tag, and custom sanitizer checks apply to foreach `<script>` templates as they do everywhere else via `parseHtmlFragment`.

## Testing

All 158 existing foreach tests pass (happy-dom + chromium).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTML sanitization being bypassed for script-based foreach templates. Templates now properly enforce size limits, nested script detection, and HTML sanitization checks. Applications that embed script markup in foreach templates must enable `allowScriptTagsInTemplates: true`.

* **Tests**
  * Added comprehensive test coverage for foreach script template sanitization, including template size limit validation and nested script markup detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->