### PR TITLE
fix(deploy): use Bun.Glob, pin CI Node to 24

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v6
 
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/tko.io/package.json
+++ b/tko.io/package.json
@@ -5,7 +5,7 @@
   "description": "TKO documentation site",
   "scripts": {
     "postinstall": "patch-package",
-    "prebuild": "node ./scripts/generate-verified-behaviors.mjs && mkdir -p public/lib && cd ../builds/knockout && bun run build && cp dist/browser.min.js ../../tko.io/public/lib/ko.js && cd ../reference && bun run build && cp dist/browser.min.js ../../tko.io/public/lib/tko.js && cd ../../tko.io && node ./scripts/bundle-tests.mjs",
+    "prebuild": "bun ./scripts/generate-verified-behaviors.mjs && mkdir -p public/lib && cd ../builds/knockout && bun run build && cp dist/browser.min.js ../../tko.io/public/lib/ko.js && cd ../reference && bun run build && cp dist/browser.min.js ../../tko.io/public/lib/tko.js && cd ../../tko.io && bun ./scripts/bundle-tests.mjs",
     "predev": "bun run prebuild",
     "dev": "ASTRO_TELEMETRY_DISABLED=1 astro dev",
     "build": "ASTRO_TELEMETRY_DISABLED=1 astro build --force",

--- a/tko.io/scripts/bundle-tests.mjs
+++ b/tko.io/scripts/bundle-tests.mjs
@@ -25,7 +25,6 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { glob } from 'node:fs/promises'
 import * as esbuild from 'esbuild'
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url))
@@ -55,16 +54,19 @@ const distToSrcPlugin = {
   }
 }
 
+// Script runs under Bun (see `prebuild` in tko.io/package.json).
+// `Bun.Glob` is portable to both Bun and the dev `bun --watch`
+// path, so no Node 22+ dependency.
 async function collectSpecs(patterns) {
-  const specs = []
+  const specs = new Set()
   for (const pattern of patterns) {
-    for await (const match of glob(pattern, { cwd: repoRoot })) {
+    const g = new Bun.Glob(pattern)
+    for await (const match of g.scan({ cwd: repoRoot })) {
       if (EXCLUDE.test(match)) continue
-      specs.push(path.join(repoRoot, match))
+      specs.add(path.join(repoRoot, match))
     }
   }
-  specs.sort()
-  return specs
+  return [...specs].sort()
 }
 
 function specSlug(absPath) {


### PR DESCRIPTION
## Summary

- Hotfix for `deploy-docs.yml` failing on the first post-#353 run with `SyntaxError: The requested module 'node:fs/promises' does not provide an export named 'glob'`. Ubuntu-latest ships Node 20; `node:fs/promises.glob` is Node 22+.
- Swap `node:fs/promises.glob` → `Bun.Glob` in `tko.io/scripts/bundle-tests.mjs`. The script already runs under Bun via the workspace setup, so no new dep.
- Flip `tko.io/package.json` `prebuild` entries from `node ./scripts/*.mjs` to `bun ./scripts/*.mjs` so the runtime is pinned by `.tool-versions`, not the runner default.
- Pin `deploy-docs.yml` to Node 24.x via `actions/setup-node`, matching `release.yml` and `publish-check.yml`, so any other raw `node` invocation in the pipeline is on a modern runtime.

## Test plan

- [x] Local: `cd tko.io && bun ./scripts/bundle-tests.mjs` → 145 source specs, setup, build bundle all emit.
- [x] Local: `/tests` page still reaches 2708/0/42 in ~5s.
- [ ] CI: watch deploy-docs on this branch's merge to main.