### PR TITLE
fix(tests): use this.skip() when cross-window popup is blocked

### DIFF
--- a/builds/knockout/spec/crossWindowBehaviors.js
+++ b/builds/knockout/spec/crossWindowBehaviors.js
@@ -5,7 +5,7 @@ describe('Cross-window support', function () {
     var win2 = window.open('', '_blank', 'height=150,location=no,menubar=no,toolbar=no,width=250')
 
     if (!win2) {
-      return
+      return this.skip('popup blocked — cross-window assertions cannot run')
     }
 
     var blankHtml = '<!doctype html><html><head></head><body></body></html>'

--- a/packages/bind/spec/crossWindowBehaviors.ts
+++ b/packages/bind/spec/crossWindowBehaviors.ts
@@ -50,7 +50,7 @@ describe('Cross-window support', function () {
     const win2 = window.open('', '_blank', 'height=150,location=no,menubar=no,toolbar=no,width=250')
 
     if (!win2) {
-      return
+      return this.skip('popup blocked — cross-window assertions cannot run')
     }
 
     const previousTemplateEngine = nativeTemplateEngine.instance

--- a/packages/bind/spec/crossWindowBehaviors.ts
+++ b/packages/bind/spec/crossWindowBehaviors.ts
@@ -50,7 +50,9 @@ describe('Cross-window support', function () {
     const win2 = window.open('', '_blank', 'height=150,location=no,menubar=no,toolbar=no,width=250')
 
     if (!win2) {
-      return this.skip('popup blocked — cross-window assertions cannot run')
+      // Popup blocked — skip so mocha reports pending (○) instead
+      // of silently passing with zero assertions.
+      return this.skip()
     }
 
     const previousTemplateEngine = nativeTemplateEngine.instance


### PR DESCRIPTION
## Summary

Both cross-window specs (`builds/knockout/spec/crossWindowBehaviors.js:7`, `packages/bind/spec/crossWindowBehaviors.ts:52`) silently `return` when `window.open` yields null because of the popup blocker. Mocha counts a sync function that throws nothing as a **pass**, so under any browser with popups blocked the suite went green while every cross-window assertion was actually skipped — a silent coverage gap noticed while running the new `/tests` runner on tko.io.

Swap the bare `return` for `return this.skip('popup blocked — cross-window assertions cannot run')` so the suite reports these as pending (○) in the stats chip. Blocked-popup state is now visible.

## Test plan

- [x] `/tests` still reaches 2708/0/42 in ~5.5s when popups are allowed (no behavioral change).
- [ ] Verify that with popups blocked, the two specs shift from ✓ to ○ rather than silently passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cross-window test reporting to explicitly skip with a clear message when popups are blocked, providing clearer test feedback instead of silent early exits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->