### PR TITLE
docs(agents): spell out tooling conventions (bunx, Bun-native APIs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,9 @@ Builds: `@tko/build.knockout` (backwards-compatible) and
 ## Prerequisites
 
 - **Bun** — package manager and script runner. Install via [mise](https://mise.jdx.dev/): `mise install` (reads `.tool-versions`), or [bun.sh](https://bun.sh).
-- Use `bun install` instead of `npm install`.
+- Use `bun install` instead of `npm install`; `bunx` instead of `npx`.
+- In repo scripts (`tko.io/scripts`, `tools/`, `builds/*/build.ts`), prefer native Bun APIs — `Bun.Glob`, `Bun.file`, `Bun.write`, `Bun.$` — over `node:fs`, `node:fs/promises.glob`, or ad-hoc `child_process`. Runtime is pinned by `.tool-versions`, so there's no Node-version portability concern.
+- Browser automation uses `bunx @playwright/cli <cmd>` (not `npx playwright`, not the deprecated `playwright-cli` package).
 
 ## Build Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,8 +44,8 @@ Builds: `@tko/build.knockout` (backwards-compatible) and
 
 - **Bun** — package manager and script runner. Install via [mise](https://mise.jdx.dev/): `mise install` (reads `.tool-versions`), or [bun.sh](https://bun.sh).
 - Use `bun install` instead of `npm install`; `bunx` instead of `npx`.
-- In repo scripts (`tko.io/scripts`, `tools/`, `builds/*/build.ts`), prefer native Bun APIs — `Bun.Glob`, `Bun.file`, `Bun.write`, `Bun.$` — over `node:fs`, `node:fs/promises.glob`, or ad-hoc `child_process`. Runtime is pinned by `.tool-versions`, so there's no Node-version portability concern.
-- Browser automation uses `bunx @playwright/cli <cmd>` (not `npx playwright`, not the deprecated `playwright-cli` package).
+- In repo scripts (`tko.io/scripts`, `tools/`), prefer native Bun APIs — `Bun.Glob`, `Bun.file`, `Bun.write`, `Bun.$` — over `node:fs`, the `glob` export from `node:fs/promises`, or ad-hoc `child_process`. Runtime is pinned by `.tool-versions`, so there's no Node-version portability concern.
+- Browser automation uses `bunx playwright <cmd>` via the repo's `playwright` dependency (not `npx playwright`, not the deprecated `playwright-cli` package).
 
 ## Build Commands
 


### PR DESCRIPTION
## Summary

Three short lines under **Prerequisites** in \`AGENTS.md\` so these conventions live in the canonical agent-context file instead of being scattered across session memory:

- \`bunx\` over \`npx\`.
- Prefer native Bun APIs (\`Bun.Glob\`, \`Bun.file\`, \`Bun.write\`, \`Bun.\$\`) over \`node:fs\` / \`node:fs/promises.glob\` / ad-hoc \`child_process\` in repo scripts. Runtime is pinned by \`.tool-versions\` so there's no Node-portability concern.
- Browser automation uses \`bunx @playwright/cli <cmd>\` (not \`playwright-cli\` (deprecated), not \`npx playwright\`).

Motivated by the PR #357 cleanup — when I originally reached for \`fs.readdir\` instead of \`Bun.Glob\` in bundle-tests.mjs. Writing the rule down here means the next agent reading AGENTS.md doesn't have to learn it by correction.

## Test plan

- [x] No code changes; docs only.