### PR TITLE
🐛 Add error callback to AMD require in component loader

### DIFF
--- a/packages/utils.component/src/loaders.ts
+++ b/packages/utils.component/src/loaders.ts
@@ -275,8 +275,10 @@ function possiblyGetConfigFromAmd(errorCallback, config, callback) {
   if (typeof config.require === 'string') {
     // The config is the value of an AMD module
     if (window.amdRequire || window.require) {
-      ;(window.amdRequire || window.require)([config.require], callback, function (err) {
-        errorCallback('Failed to load AMD module: ' + config.require + (err ? ' — ' + err.message : ''))
+      const amdRequire = window.amdRequire || window.require
+      amdRequire([config.require], callback, function (err) {
+        const details = err?.message ?? String(err || '')
+        errorCallback('Failed to load AMD module: ' + config.require + (details ? ' — ' + details : ''))
       })
     } else {
       errorCallback('Uses require, but no AMD loader is present')

--- a/packages/utils.component/src/loaders.ts
+++ b/packages/utils.component/src/loaders.ts
@@ -275,7 +275,9 @@ function possiblyGetConfigFromAmd(errorCallback, config, callback) {
   if (typeof config.require === 'string') {
     // The config is the value of an AMD module
     if (window.amdRequire || window.require) {
-      ;(window.amdRequire || window.require)([config.require], callback)
+      ;(window.amdRequire || window.require)([config.require], callback, function (err) {
+        errorCallback('Failed to load AMD module: ' + config.require + (err ? ' — ' + err.message : ''))
+      })
     } else {
       errorCallback('Uses require, but no AMD loader is present')
     }


### PR DESCRIPTION
## Problem

The AMD `require` call in `possiblyGetConfigFromAmd` (`packages/utils.component/src/loaders.ts`) passed only a success callback — no error callback. When AMD module resolution fails, the error is silently swallowed, leaving the component load hanging with no diagnostic.

## Fix

Add an explicit error callback (third argument) to the AMD `require` call that surfaces the failure through the existing `errorCallback` mechanism, producing a clear message like:

> Component 'my-comp': Failed to load AMD module: some/module — Error details…

## Changes

- `packages/utils.component/src/loaders.ts`: Add error callback to the `(window.amdRequire || window.require)` call.

## Verification

- All 106 existing `utils.component` tests pass.
- No API surface change — purely an additive error path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module loading error messages: failures now include the module name and more detailed diagnostic text (when available) to help identify root causes.
  * Ensures consistent behavior when using a browser loader, preserving previous behavior for other cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->