### PR TITLE
Fix Parser instantiation and globals in ComponentProvider

### DIFF
--- a/.changeset/fix-component-provider-parser-globals.md
+++ b/.changeset/fix-component-provider-parser-globals.md
@@ -1,0 +1,10 @@
+---
+"@tko/provider.component": patch
+---
+
+Fix component params globals resolution in `ComponentProvider`.
+
+`getComponentParams` now instantiates `Parser` with `new Parser()` and passes
+provider globals to `parser.parse(...)`, matching canonical parser usage in
+other providers. This restores resolution of globals in component `params`
+expressions (for example, `params="answer: GLOBAL_CONST"`).

--- a/packages/provider.component/spec/componentProviderBehaviors.ts
+++ b/packages/provider.component/spec/componentProviderBehaviors.ts
@@ -150,6 +150,29 @@ describe('Components: Provider', function () {
       applyBindings({}, ne)
       // No error raised.
     })
+
+    it('resolves globals in component params', function () {
+      const provider = new MultiProvider({
+        providers: [new DataBindProvider(), new ComponentProvider()],
+        globals: { GLOBAL_CONST: 42 }
+      })
+      options.bindingProviderInstance = provider
+      bindingHandlers = provider.bindingHandlers
+      bindingHandlers.set(componentBindings)
+      bindingHandlers.set(coreBindings)
+
+      components.register('xenon', {
+        viewModel: function (params) {
+          expect(params.answer).to.equal(42)
+        },
+        template: '<span>ok</span>',
+        synchronous: true,
+        ignoreCustomElementWarning: true
+      })
+      const xe = document.createElement('xenon')
+      xe.setAttribute('params', 'answer: GLOBAL_CONST')
+      applyBindings({}, xe)
+    })
   })
 
   /* describe("nodeParamsToObject", function() {

--- a/packages/provider.component/src/ComponentProvider.ts
+++ b/packages/provider.component/src/ComponentProvider.ts
@@ -72,9 +72,9 @@ export default class ComponentProvider extends Provider {
       return { $raw: {} }
     }
 
-    const parser = new (Parser as any)(node, context, this.globals) as Parser
+    const parser = new Parser()
     const paramsString = (node.getAttribute('params') || '').trim()
-    const accessors = parser.parse(paramsString, context, undefined, node)
+    const accessors = parser.parse(paramsString, context, this.globals, node)
     if (!accessors || Object.keys(accessors).length === 0) {
       return { $raw: {} }
     }

--- a/packages/utils.parser/src/Parser.ts
+++ b/packages/utils.parser/src/Parser.ts
@@ -32,11 +32,7 @@ type InnerFilterType = (value: any, ignored: any, context: any, globals: any, no
 type FilterType = InnerFilterType & { precedence: number }
 
 /**
- * Construct a new Parser instance with new Parser(node, context)
- * @param {Node} node    The DOM element from which we parsed the
- *                         content.
- * @param {object} context The Knockout context.
- * @param {object} globals An object containing any desired globals.
+ * Parser for binding and params expressions.
  */
 export default class Parser {
   ch: any


### PR DESCRIPTION
## Summary

`ComponentProvider.getComponentParams` was instantiating `Parser` with a downcast (`new (Parser as any)(node, context, this.globals)`) and passing `undefined` as globals to `.parse()`. Since `Parser` takes no constructor arguments, the globals were silently dropped — global variables could never resolve in component params.

## Changes

- **`ComponentProvider.ts`**: Replace `new (Parser as any)(node, context, this.globals) as Parser` with `new Parser()`, and pass `this.globals` to `.parse()` instead of `undefined`. This matches how every other provider (`BindingStringProvider`, `mustacheParser`) uses `Parser`.
- **`componentProviderBehaviors.ts`**: Add test that registers a component with `params="answer: GLOBAL_CONST"` where `GLOBAL_CONST` is provided via provider globals, verifying globals resolution in component params.

## Verification

All 52 existing tests pass (chromium + happy-dom). New test passes in both environments.