### PR TITLE
Fix removeEventListener missing options in LifeCycle

### DIFF
--- a/packages/lifecycle/spec/LifeCycleBehaviors.ts
+++ b/packages/lifecycle/spec/LifeCycleBehaviors.ts
@@ -247,5 +247,30 @@ describe('KO LifeCycle', function () {
       assert.equal(divClick, 2)
       assert.equal(anchorClick, 2)
     })
+
+    it('addEventListener with capture option removes listener on dispose', function () {
+      let clicks = 0
+      const parent = document.createElement('div')
+      const child = document.createElement('span')
+      parent.appendChild(child)
+      document.body.appendChild(parent)
+
+      class CaptureLC extends LifeCycle {
+        constructor() {
+          super()
+          this.addEventListener(parent, 'click', () => clicks++, { capture: true })
+        }
+      }
+
+      const lc = new CaptureLC()
+      child.click()
+      assert.equal(clicks, 1)
+
+      lc.dispose()
+      child.click()
+      assert.equal(clicks, 1, 'capture listener should be removed after dispose')
+
+      document.body.removeChild(parent)
+    })
   })
 })

--- a/packages/lifecycle/src/LifeCycle.ts
+++ b/packages/lifecycle/src/LifeCycle.ts
@@ -68,7 +68,7 @@ export default class LifeCycle {
   __addEventListener(node, eventType, handler, options) {
     node.addEventListener(eventType, handler, options)
     function dispose() {
-      node.removeEventListener(eventType, handler)
+      node.removeEventListener(eventType, handler, options)
     }
     addDisposeCallback(node, dispose)
     this.addDisposable({ dispose })


### PR DESCRIPTION
## Problem

`LifeCycle.__addEventListener` registers listeners with `addEventListener(type, handler, options)` but disposes them with `removeEventListener(type, handler)` — without passing `options`.

Per the DOM spec, `removeEventListener` must match the `capture` flag used during registration. Without it, capture-phase listeners remain attached after disposal, leaking event handlers.

## Fix

Pass `options` through to `removeEventListener` in the dispose callback.

## Test

Added a test that registers a capture-phase listener, verifies it fires, disposes the LifeCycle, and confirms the listener no longer fires.