### PR TITLE
deps(tko.io): use static JSON imports for pkg + test manifest

### DIFF
--- a/tko.io/src/components/Header.astro
+++ b/tko.io/src/components/Header.astro
@@ -1,7 +1,6 @@
 ---
 import config from 'virtual:starlight/user-config';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import pkg from '../../../builds/knockout/package.json';
 
 import LanguageSelect from 'virtual:starlight/components/LanguageSelect';
 import Search from 'virtual:starlight/components/Search';
@@ -12,7 +11,6 @@ import ThemeSelect from 'virtual:starlight/components/ThemeSelect';
 const shouldRenderSearch =
 	config.pagefind || config.components.Search !== '@astrojs/starlight/components/Search.astro';
 
-const pkg = JSON.parse(readFileSync(join(process.cwd(), '../builds/knockout/package.json'), 'utf8'));
 const version = pkg.version;
 ---
 

--- a/tko.io/src/pages/tests.astro
+++ b/tko.io/src/pages/tests.astro
@@ -1,6 +1,4 @@
 ---
-import { join } from 'node:path'
-
 // Read the source-mode chunk list at SSR time so the HTML ships
 // with <link rel="modulepreload"> for every shared chunk already
 // in <head>. The browser starts warming the HTTP cache during
@@ -9,10 +7,8 @@ import { join } from 'node:path'
 // iframes with the opaque "Importing a module script failed."
 // error. `prebuild` always runs bundle-tests.mjs before Astro
 // builds the site, so manifest.json is guaranteed to exist.
-// Resolve from cwd (project root) — import.meta.url points into
-// dist/.prerender/chunks/ under Astro 6's prerender bundler.
-const manifestPath = join(process.cwd(), 'public/tests/source/manifest.json')
-const sourceChunks: string[] = (await Bun.file(manifestPath).json()).chunks ?? []
+import manifest from '../../public/tests/source/manifest.json'
+const sourceChunks: string[] = manifest.chunks ?? []
 
 // TKO Browser Test Runner — written in TKO itself.
 //


### PR DESCRIPTION
## Summary

Follow-up to #360. Replaces the \`process.cwd()\`-relative \`readFileSync\` / \`Bun.file\` calls in \`Header.astro\` and \`tests.astro\` with direct static JSON imports.

Vite inlines the data at build time, so there is no runtime path resolution and no dependency on cwd being \`tko.io/\`.

## Why

Adversarial review on #360 flagged that \`process.cwd()\` assumes \`astro build\` is invoked from \`tko.io/\`. CI does that (\`cd tko.io && bun run build\`), but any future script running from the repo root would silently produce a missing Header version badge and an empty \`/tests\` chunk list.

Static JSON imports remove the assumption entirely — the build fails loudly at import time if a file is missing, and cwd stops mattering.

## Test plan

- [x] \`bun run build\` → 66 pages, clean
- [x] \`TKO v4.0.1\` rendered in Header via imported \`builds/knockout/package.json\`
- [x] 32 \`<link rel=modulepreload>\` entries emitted on \`/tests\` from imported manifest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved application startup performance by optimizing how configuration and resource data are loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->