### PR TITLE
fix(binding.foreach): add afterRender/beforeMove/afterMove callbacks (#329)

### DIFF
--- a/.changeset/fix-foreach-callback-api.md
+++ b/.changeset/fix-foreach-callback-api.md
@@ -1,0 +1,9 @@
+---
+"@tko/binding.foreach": patch
+---
+
+Add documented `foreach` lifecycle callbacks to `ForEachBinding`:
+`afterRender(nodes, value)` fires when an item is rendered from the template,
+`beforeMove(node, newIndex, value)` and `afterMove(node, newIndex, value)` fire
+for retained items that shift position. The existing `afterAdd` and
+`beforeRemove` signatures are unchanged.

--- a/packages/binding.foreach/spec/eachBehavior.ts
+++ b/packages/binding.foreach/spec/eachBehavior.ts
@@ -22,7 +22,7 @@ import { bindings as coreBindings } from '@tko/binding.core'
 
 import { ForEachBinding } from '../dist/foreach'
 
-import $ from 'jquery'
+import $ from 'jquery' //TODO Should be removed and replaced with direct DOM manipulation
 
 import { assert } from 'chai'
 
@@ -854,6 +854,40 @@ describe('observable array changes', function () {
         { text: 'a', value: 'a' },
         { text: 'b', value: 'b' }
       ])
+    })
+
+    it('does not re-render when an observable read inside afterRender changes', function () {
+      const testNode = document.createElement('div')
+      testNode.innerHTML =
+        "<div data-bind='foreach: { data: someItems, afterRender: callback }'><span data-bind='text: childprop'></span></div>"
+
+      const callbackObservable = observable(1)
+      const someItems = observableArray([{ childprop: 'first child' }])
+      let callbacks = 0
+
+      applyBindings(
+        {
+          someItems,
+          callback: function () {
+            callbackObservable()
+            callbacks++
+          }
+        },
+        testNode
+      )
+      assert.equal(callbacks, 1)
+
+      // Mutate the underlying array without notifying — foreach must not re-render.
+      someItems().push({ childprop: 'hidden child' })
+      assert.equal(testNode.childNodes[0].textContent, 'first child')
+
+      // Changing an observable that was only *read* inside afterRender must not re-render.
+      callbackObservable(2)
+      assert.equal(testNode.childNodes[0].textContent, 'first child')
+
+      // Now notify — the new child should appear.
+      someItems.valueHasMutated()
+      assert.equal(testNode.childNodes[0].textContent, 'first childhidden child')
     })
   })
 

--- a/packages/binding.foreach/spec/eachBehavior.ts
+++ b/packages/binding.foreach/spec/eachBehavior.ts
@@ -856,6 +856,29 @@ describe('observable array changes', function () {
       ])
     })
 
+    it('fires for reused nodesets when an item is re-inserted from pendingDeletes', function () {
+      const a = { name: 'a' }
+      const b = { name: 'b' }
+      const c = { name: 'c' }
+      const calls: any[] = []
+      const arr = observableArray([a, b, c])
+      function cb(nodes, value) {
+        calls.push({ text: nodes.map(node => node.textContent).join(''), value })
+      }
+      const target = $("<ul data-bind='foreach: { data: arr, afterRender: cb }'><li data-bind='text: name'></li></div>")
+      applyBindings({ arr: arr, cb: cb }, target[0])
+      assert.equal(calls.length, 3)
+
+      // Reverse moves `a` and `c` via delete+add pairs whose nodesets are
+      // recycled through pendingDeletes (`b` is retained in place). afterRender
+      // must fire for each reinsertion of the recycled nodes.
+      arr.reverse()
+      assert.equal(target.text(), 'cba')
+      const reusedValues = calls.slice(3).map(call => call.value)
+      assert.includeMembers(reusedValues, [a, c])
+      assert.notInclude(reusedValues, b)
+    })
+
     it('does not re-render when an observable read inside afterRender changes', function () {
       const testNode = document.createElement('div')
       testNode.innerHTML =
@@ -925,6 +948,29 @@ describe('observable array changes', function () {
         value: first,
         parentText: 'addedfirst'
       })
+    })
+
+    it('does not fire for primitives whose index changes (no node identity is preserved)', function () {
+      // Primitive values are torn down in `deleted()` and re-rendered fresh in
+      // `added()` (no `pendingDeletes` reuse), so the documented `(node, index,
+      // value)` move contract — the *same* DOM node moved — does not apply.
+      const calls: any[] = []
+      const arr = observableArray(['a'])
+      function beforeMove(_node, index, value) {
+        calls.push({ phase: 'before', index, value })
+      }
+      function afterMove(_node, index, value) {
+        calls.push({ phase: 'after', index, value })
+      }
+      const target = $(
+        "<ul data-bind='foreach: { data: arr, beforeMove: beforeMove, afterMove: afterMove }'><li data-bind='text: $data'></li></div>"
+      )
+      applyBindings({ arr: arr, beforeMove: beforeMove, afterMove: afterMove }, target[0])
+
+      arr.splice(0, 0, 'added')
+
+      assert.equal(target.text(), 'addeda')
+      assert.equal(calls.length, 0)
     })
   })
 

--- a/packages/binding.foreach/spec/eachBehavior.ts
+++ b/packages/binding.foreach/spec/eachBehavior.ts
@@ -863,20 +863,40 @@ describe('observable array changes', function () {
       const calls: any[] = []
       const arr = observableArray([a, b, c])
       function cb(nodes, value) {
-        calls.push({ text: nodes.map(node => node.textContent).join(''), value })
+        calls.push({
+          nodes: Array.from(nodes),
+          text: nodes.map(node => node.textContent).join(''),
+          value
+        })
       }
       const target = $("<ul data-bind='foreach: { data: arr, afterRender: cb }'><li data-bind='text: name'></li></div>")
       applyBindings({ arr: arr, cb: cb }, target[0])
       assert.equal(calls.length, 3)
+      const initialNodesByValue = new Map(calls.map(call => [call.value, call.nodes]))
 
       // Reverse moves `a` and `c` via delete+add pairs whose nodesets are
       // recycled through pendingDeletes (`b` is retained in place). afterRender
       // must fire for each reinsertion of the recycled nodes.
       arr.reverse()
       assert.equal(target.text(), 'cba')
-      const reusedValues = calls.slice(3).map(call => call.value)
-      assert.includeMembers(reusedValues, [a, c])
+      assert.equal(calls.length, 5)
+      const reusedCalls = calls.slice(3)
+      const reusedValues = reusedCalls.map(call => call.value)
+      const reusedCallsByValue = new Map(reusedCalls.map(call => [call.value, call]))
+      assert.sameMembers(reusedValues, [a, c])
       assert.notInclude(reusedValues, b)
+      arrayForEach([a, c], value => {
+        const initialNodes = initialNodesByValue.get(value)!
+        const reusedCall = reusedCallsByValue.get(value)!
+        assert.equal(reusedCall.nodes.length, initialNodes.length)
+        arrayForEach(reusedCall.nodes, (node, index) => {
+          assert.strictEqual(node, initialNodes[index!])
+        })
+      })
+      const finalNodes = Array.from(target[0].childNodes)
+      arrayForEach([c, b, a], (value, index) => {
+        assert.strictEqual(finalNodes[index!], initialNodesByValue.get(value)![0])
+      })
     })
 
     it('does not re-render when an observable read inside afterRender changes', function () {
@@ -911,6 +931,64 @@ describe('observable array changes', function () {
       // Now notify — the new child should appear.
       someItems.valueHasMutated()
       assert.equal(testNode.childNodes[0].textContent, 'first childhidden child')
+    })
+
+    it('clears pending afterRender calls when afterRender throws', function () {
+      const error = new Error('afterRender failed')
+      const calls: any[] = []
+      const instance = {
+        pendingAfterRender: [{ nodes: [], value: 'a' }],
+        afterRender(nodes, value) {
+          calls.push({ nodes, value })
+          throw error
+        }
+      }
+      let thrown
+
+      try {
+        ForEachBinding.prototype.flushPendingAfterRender.call(instance)
+      } catch (err) {
+        thrown = err
+      }
+
+      assert.strictEqual(thrown, error)
+      assert.deepEqual(instance.pendingAfterRender, [])
+      assert.deepEqual(calls, [{ nodes: [], value: 'a' }])
+    })
+
+    it('updates conditional state and does not replay a completed queue after afterRender throws', function () {
+      const a = { name: 'a' }
+      const b = { name: 'b' }
+      const error = new Error('afterRender failed')
+      const calls: any[] = []
+      const arr = observableArray<typeof a>([])
+      let shouldThrow = false
+      function cb(_nodes, value) {
+        calls.push(value)
+        if (shouldThrow) {
+          throw error
+        }
+      }
+      const target = $("<ul data-bind='foreach: { data: arr, afterRender: cb }'><li data-bind='text: name'></li></ul>")
+      applyBindings({ arr: arr, cb: cb }, target[0])
+      shouldThrow = true
+      let thrown
+
+      try {
+        arr.push(a)
+      } catch (err) {
+        thrown = err
+      }
+
+      assert.strictEqual(thrown, error)
+      assert.equal(target.text(), 'a')
+      assert.equal(domData.get(target[0], 'conditional').elseChainSatisfied(), true)
+
+      shouldThrow = false
+      arr.push(b)
+
+      assert.equal(target.text(), 'ab')
+      assert.deepEqual(calls, [a, b])
     })
   })
 
@@ -971,6 +1049,51 @@ describe('observable array changes', function () {
 
       assert.equal(target.text(), 'addeda')
       assert.equal(calls.length, 0)
+    })
+
+    it('fires once per DOM node for moved multi-root item templates', function () {
+      const first = { firstLabel: 'first-a', secondLabel: 'first-b' }
+      const added = { firstLabel: 'added-a', secondLabel: 'added-b' }
+      const calls: any[] = []
+      const arr = observableArray([first])
+      function beforeMove(node, index, value) {
+        calls.push({ phase: 'before', node, text: node.textContent, index, value })
+      }
+      function afterMove(node, index, value) {
+        calls.push({ phase: 'after', node, text: node.textContent, index, value })
+      }
+      const target = $(
+        "<ul data-bind='foreach: { data: arr, beforeMove: beforeMove, afterMove: afterMove }'>" +
+          "<li data-bind='text: firstLabel'></li><li data-bind='text: secondLabel'></li></ul>"
+      )
+      applyBindings({ arr: arr, beforeMove: beforeMove, afterMove: afterMove }, target[0])
+      const movedNodes = Array.from(target[0].childNodes)
+
+      arr.splice(0, 0, added)
+
+      assert.equal(target.text(), 'added-aadded-bfirst-afirst-b')
+      assert.equal(calls.length, 4)
+      assert.deepEqual(
+        calls.map(({ phase, text, index }) => ({ phase, text, index })),
+        [
+          { phase: 'before', text: 'first-a', index: 1 },
+          { phase: 'before', text: 'first-b', index: 1 },
+          { phase: 'after', text: 'first-a', index: 1 },
+          { phase: 'after', text: 'first-b', index: 1 }
+        ]
+      )
+      const callbackNodes = calls.map(call => call.node)
+      const expectedCallbackNodes = [movedNodes[0], movedNodes[1], movedNodes[0], movedNodes[1]]
+      arrayForEach(expectedCallbackNodes, (node, index) => {
+        assert.strictEqual(callbackNodes[index!], node)
+      })
+      const finalMovedNodes = Array.from(target[0].childNodes).slice(2)
+      arrayForEach(movedNodes, (node, index) => {
+        assert.strictEqual(finalMovedNodes[index!], node)
+      })
+      arrayForEach(calls, call => {
+        assert.strictEqual(call.value, first)
+      })
     })
   })
 

--- a/packages/binding.foreach/spec/eachBehavior.ts
+++ b/packages/binding.foreach/spec/eachBehavior.ts
@@ -993,6 +993,58 @@ describe('observable array changes', function () {
   })
 
   describe('beforeMove and afterMove', function () {
+    it('cleans queue state when move callbacks or queue processing throws', function () {
+      arrayForEach(['beforeMove', 'changeQueue', 'afterMove'], phase => {
+        const value = { name: phase }
+        const error = new Error(`${phase} failed`)
+        const instance: any = {
+          data: observableArray([value]),
+          changeQueue: [{ status: 'added', index: 0, value }],
+          rendering_queued: true,
+          pendingAfterRender: [{ nodes: [], value }],
+          isNotEmpty: observable(false),
+          $indexHasBeenRequested: false,
+          beforeMove() {},
+          afterMove() {},
+          computeMoves() {
+            return [{ value, oldIndex: 0, newIndex: 1 }]
+          },
+          startQueueFlush() {},
+          fireMoveCallback(callback) {
+            if (phase === 'beforeMove' && callback === this.beforeMove) {
+              throw error
+            }
+            if (phase === 'afterMove' && callback === this.afterMove) {
+              throw error
+            }
+          },
+          added() {
+            if (phase === 'changeQueue') {
+              throw error
+            }
+          },
+          flushPendingDeletes() {},
+          flushPendingAfterRender() {
+            this.pendingAfterRender = new Array()
+          },
+          endQueueFlush() {}
+        }
+        let thrown
+
+        try {
+          ForEachBinding.prototype.processQueue.call(instance)
+        } catch (err) {
+          thrown = err
+        }
+
+        assert.strictEqual(thrown, error)
+        assert.equal(instance.rendering_queued, false)
+        assert.deepEqual(instance.changeQueue, [])
+        assert.deepEqual(instance.pendingAfterRender, [])
+        assert.equal(instance.isNotEmpty(), true)
+      })
+    })
+
     it('fire with the retained node, its new index, and its value when items shift', function () {
       const first = { name: 'first' }
       const added = { name: 'added' }
@@ -1026,6 +1078,30 @@ describe('observable array changes', function () {
         value: first,
         parentText: 'addedfirst'
       })
+    })
+
+    it('fires for every retained node when the array is reversed', function () {
+      const items = ['a', 'b', 'c'].map(name => ({ name }))
+      const calls: Array<{ phase: string; index: number; value: any }> = []
+      const arr = observableArray(items)
+      const target = $(
+        "<ul data-bind='foreach: { data: arr, beforeMove: beforeMove, afterMove: afterMove }'><li data-bind='text: name'></li></div>"
+      )
+      applyBindings(
+        {
+          arr,
+          beforeMove: (_n, index, value) => calls.push({ phase: 'before', index, value }),
+          afterMove: (_n, index, value) => calls.push({ phase: 'after', index, value })
+        },
+        target[0]
+      )
+      arr.reverse()
+
+      // a: old index 0, new index 2 → moved
+      // b: old index 1, new index 1 → retained, but not moved
+      // c: old index 2, new index 0 → moved
+      // 2 moved items * (beforeMove + afterMove) = 4 calls
+      assert.equal(calls.length, 4)
     })
 
     it('does not fire for primitives whose index changes (no node identity is preserved)', function () {

--- a/packages/binding.foreach/spec/eachBehavior.ts
+++ b/packages/binding.foreach/spec/eachBehavior.ts
@@ -836,6 +836,64 @@ describe('observable array changes', function () {
     })
   })
 
+  describe('afterRender', function () {
+    it('is called with rendered nodes and the array value for initial and added items', function () {
+      const calls: any[] = []
+      const arr = observableArray(['a'])
+      function cb(nodes, value) {
+        calls.push({ text: nodes.map(node => node.textContent).join(''), value })
+      }
+      const target = $(
+        "<ul data-bind='foreach: { data: arr, afterRender: cb }'><li data-bind='text: $data'></li></div>"
+      )
+      applyBindings({ arr: arr, cb: cb }, target[0])
+
+      assert.deepEqual(calls, [{ text: 'a', value: 'a' }])
+      arr.push('b')
+      assert.deepEqual(calls, [
+        { text: 'a', value: 'a' },
+        { text: 'b', value: 'b' }
+      ])
+    })
+  })
+
+  describe('beforeMove and afterMove', function () {
+    it('fire with the retained node, its new index, and its value when items shift', function () {
+      const first = { name: 'first' }
+      const added = { name: 'added' }
+      const calls: any[] = []
+      const arr = observableArray([first])
+      function beforeMove(node, index, value) {
+        calls.push({ phase: 'before', text: node.textContent, index, value, parentText: node.parentNode.textContent })
+      }
+      function afterMove(node, index, value) {
+        calls.push({ phase: 'after', text: node.textContent, index, value, parentText: node.parentNode.textContent })
+      }
+      const target = $(
+        "<ul data-bind='foreach: { data: arr, beforeMove: beforeMove, afterMove: afterMove }'><li data-bind='text: name'></li></div>"
+      )
+      applyBindings({ arr: arr, beforeMove: beforeMove, afterMove: afterMove }, target[0])
+
+      arr.splice(0, 0, added)
+
+      assert.equal(calls.length, 2)
+      assert.deepEqual(calls[0], {
+        phase: 'before',
+        text: 'first',
+        index: 1,
+        value: first,
+        parentText: 'first'
+      })
+      assert.deepEqual(calls[1], {
+        phase: 'after',
+        text: 'first',
+        index: 1,
+        value: first,
+        parentText: 'addedfirst'
+      })
+    })
+  })
+
   describe('$index', function () {
     it('is present on the children', function () {
       const target = $("<ul data-bind='foreach: $data'><li data-bind='text: $data'></li></ul>")

--- a/packages/binding.foreach/src/foreach.ts
+++ b/packages/binding.foreach/src/foreach.ts
@@ -256,29 +256,30 @@ export class ForEachBinding extends AsyncBindingHandler {
     let lowestIndexChanged = MAX_LIST_SIZE
     const moves = this.computeMoves(unwrap(this.data) || [])
 
-    this.startQueueFlush()
-    this.fireMoveCallback(this.beforeMove, moves, 'oldIndex')
-
-    arrayForEach(this.changeQueue, changeItem => {
-      if (typeof changeItem.index === 'number') {
-        lowestIndexChanged = Math.min(lowestIndexChanged, changeItem.index)
-      }
-      this[changeItem.status](changeItem)
-    })
-    this.flushPendingDeletes()
-    this.rendering_queued = false
-
-    // Update our indexes.
-    if (this.$indexHasBeenRequested) {
-      this.updateIndexes(lowestIndexChanged)
-    }
-
-    this.fireMoveCallback(this.afterMove, moves, 'newIndex')
     try {
+      this.startQueueFlush()
+      this.fireMoveCallback(this.beforeMove, moves, 'oldIndex')
+
+      arrayForEach(this.changeQueue, changeItem => {
+        if (typeof changeItem.index === 'number') {
+          lowestIndexChanged = Math.min(lowestIndexChanged, changeItem.index)
+        }
+        this[changeItem.status](changeItem)
+      })
+      this.flushPendingDeletes()
+
+      // Update our indexes.
+      if (this.$indexHasBeenRequested) {
+        this.updateIndexes(lowestIndexChanged)
+      }
+
+      this.fireMoveCallback(this.afterMove, moves, 'newIndex')
       this.flushPendingAfterRender()
       this.endQueueFlush()
     } finally {
+      this.rendering_queued = false
       this.changeQueue = new Array()
+      this.pendingAfterRender = new Array()
       // Update the conditional exposed on the domData
       if (isEmpty !== !this.isNotEmpty()) {
         this.isNotEmpty(!isEmpty)

--- a/packages/binding.foreach/src/foreach.ts
+++ b/packages/binding.foreach/src/foreach.ts
@@ -273,12 +273,18 @@ export class ForEachBinding extends AsyncBindingHandler {
 
   // Detect items that remain in the new array but at a different index than in
   // firstLastNodesList. Only compute if any move callback is registered.
+  // Limited to values that satisfy `shouldDelayDeletion`; primitives are torn
+  // down in `deleted()` and re-rendered in `added()`, so they are not "moved"
+  // in the documented sense (no node identity is preserved).
   computeMoves(newValues: any[]): { value: any; oldIndex: number; newIndex: number }[] {
     if (typeof this.beforeMove !== 'function' && typeof this.afterMove !== 'function') {
       return []
     }
     const oldByValue = new Map<any, number[]>()
     this.firstLastNodesList.forEach((entry, oldIndex) => {
+      if (!this.shouldDelayDeletion(entry.value)) {
+        return
+      }
       const list = oldByValue.get(entry.value) || []
       list.push(oldIndex)
       oldByValue.set(entry.value, list)
@@ -289,7 +295,10 @@ export class ForEachBinding extends AsyncBindingHandler {
       if (!list || list.length === 0) {
         return
       }
-      const oldIndex = list.shift()!
+      // Pop (rightmost) to align with `pendingDelete.nodesets.pop()` reuse
+      // order in `added()`, so duplicate-value pairings track the actual
+      // recycled nodeset.
+      const oldIndex = list.pop()!
       if (oldIndex !== newIndex) {
         moves.push({ value, oldIndex, newIndex })
       }
@@ -405,12 +414,17 @@ export class ForEachBinding extends AsyncBindingHandler {
     const asyncBindingResults = new Array()
     let children
 
+    const queueAfterRender = typeof this.afterRender === 'function'
+
     for (let i = 0, len = valuesToAdd.length; i < len; ++i) {
       // we check if we have a pending delete with reusable nodesets for this data, and if yes, we reuse one nodeset
       const pendingDelete = this.getPendingDeleteFor(valuesToAdd[i])
       if (pendingDelete && pendingDelete.nodesets.length) {
         children = pendingDelete.nodesets.pop()
         this.updateFirstLastNodesList(index + i, children, valuesToAdd[i])
+        if (queueAfterRender) {
+          this.pendingAfterRender.push({ nodes: Array.from(children), value: valuesToAdd[i] })
+        }
       } else {
         const templateClone = this.templateNode.cloneNode(true)
         children = virtualElements.childNodes(templateClone)
@@ -420,7 +434,9 @@ export class ForEachBinding extends AsyncBindingHandler {
         // because bindings can add childnodes.
         const bindingResult = applyBindingsToDescendants(this.generateContext(valuesToAdd[i]), templateClone)
         asyncBindingResults.push(bindingResult)
-        this.pendingAfterRender.push({ nodes: Array.from(children), value: valuesToAdd[i] })
+        if (queueAfterRender) {
+          this.pendingAfterRender.push({ nodes: Array.from(children), value: valuesToAdd[i] })
+        }
       }
 
       allChildNodes.push(...children)

--- a/packages/binding.foreach/src/foreach.ts
+++ b/packages/binding.foreach/src/foreach.ts
@@ -76,6 +76,19 @@ function valueToChangeAddItem(value, index): ChangeAddItem {
   return { status: 'added', value: value, index: index }
 }
 
+function walkSiblingRange(first: Node, last: Node): Node[] {
+  const result: Node[] = []
+  let ptr: Node | null = first
+  result.push(ptr)
+  while (ptr && ptr !== last) {
+    ptr = ptr.nextSibling
+    if (ptr) {
+      result.push(ptr)
+    }
+  }
+  return result
+}
+
 // store a symbol for caching the pending delete info index in the data item objects
 const PENDING_DELETE_INDEX_SYM = Symbol('_ko_ffe_pending_delete_index')
 
@@ -261,13 +274,15 @@ export class ForEachBinding extends AsyncBindingHandler {
     }
 
     this.fireMoveCallback(this.afterMove, moves, 'newIndex')
-    this.flushPendingAfterRender()
-    this.endQueueFlush()
-    this.changeQueue = new Array()
-
-    // Update the conditional exposed on the domData
-    if (isEmpty !== !this.isNotEmpty()) {
-      this.isNotEmpty(!isEmpty)
+    try {
+      this.flushPendingAfterRender()
+      this.endQueueFlush()
+    } finally {
+      this.changeQueue = new Array()
+      // Update the conditional exposed on the domData
+      if (isEmpty !== !this.isNotEmpty()) {
+        this.isNotEmpty(!isEmpty)
+      }
     }
   }
 
@@ -326,26 +341,19 @@ export class ForEachBinding extends AsyncBindingHandler {
   }
 
   getNodesForEntry(entry: { first: Node; last: Node }) {
-    const result: Node[] = []
-    let ptr: Node | null = entry.first
-    const last = entry.last
-    result.push(ptr)
-    while (ptr && ptr !== last) {
-      ptr = ptr.nextSibling
-      if (ptr) {
-        result.push(ptr)
-      }
-    }
-    return result
+    return walkSiblingRange(entry.first, entry.last)
   }
 
   flushPendingAfterRender() {
-    if (typeof this.afterRender === 'function') {
-      arrayForEach(this.pendingAfterRender, item => {
-        this.afterRender(item.nodes, item.value)
-      })
+    try {
+      if (typeof this.afterRender === 'function') {
+        arrayForEach(this.pendingAfterRender, item => {
+          this.afterRender(item.nodes, item.value)
+        })
+      }
+    } finally {
+      this.pendingAfterRender = new Array()
     }
-    this.pendingAfterRender = new Array()
   }
 
   /**
@@ -455,15 +463,8 @@ export class ForEachBinding extends AsyncBindingHandler {
   }
 
   getNodesForIndex(index) {
-    const result = new Array()
-    let ptr = this.firstLastNodesList[index].first
-    const last = this.firstLastNodesList[index].last
-    result.push(ptr)
-    while (ptr && ptr !== last) {
-      ptr = ptr.nextSibling!
-      result.push(ptr)
-    }
-    return result
+    const entry = this.firstLastNodesList[index]
+    return walkSiblingRange(entry.first, entry.last)
   }
 
   getLastNodeBeforeIndex(index) {

--- a/packages/binding.foreach/src/foreach.ts
+++ b/packages/binding.foreach/src/foreach.ts
@@ -13,8 +13,6 @@ import type { ObservableArray } from '@tko/observable'
 
 import { contextFor, applyBindingsToDescendants, AsyncBindingHandler } from '@tko/bind'
 
-import type { AllBindings } from '@tko/bind'
-
 //      Utilities
 const MAX_LIST_SIZE = Number.MAX_SAFE_INTEGER
 
@@ -89,8 +87,11 @@ export class ForEachBinding extends AsyncBindingHandler {
   //    computed
   //    {data: array, name: string, as: string}
   afterAdd
+  afterMove
+  afterRender
   static animateFrame
   as
+  beforeMove
   beforeRemove
   container
   changeSubs: any
@@ -99,13 +100,14 @@ export class ForEachBinding extends AsyncBindingHandler {
   $indexHasBeenRequested: boolean
   templateNode
   changeQueue: any[]
-  firstLastNodesList: { first: Node; last: Node }[]
+  firstLastNodesList: { first: Node; last: Node; value: any }[]
   indexesToDelete: any[]
   isNotEmpty: any
   rendering_queued: boolean
   pendingDeletes: any[]
   afterQueueFlush
   beforeQueueFlush
+  pendingAfterRender: { nodes: Node[]; value: any }[]
 
   constructor(params) {
     super(params)
@@ -125,7 +127,15 @@ export class ForEachBinding extends AsyncBindingHandler {
     this.templateNode = makeTemplateNode(
       settings.templateNode || (settings.name ? document.getElementById(settings.name)?.cloneNode(true) : this.$element)
     )
-    ;['afterAdd', 'beforeRemove', 'afterQueueFlush', 'beforeQueueFlush'].forEach(p => {
+    ;[
+      'afterAdd',
+      'afterMove',
+      'afterRender',
+      'beforeMove',
+      'beforeRemove',
+      'afterQueueFlush',
+      'beforeQueueFlush'
+    ].forEach(p => {
       this[p] = settings[p] || this.allBindings.get(p)
     })
 
@@ -134,6 +144,7 @@ export class ForEachBinding extends AsyncBindingHandler {
     this.indexesToDelete = new Array()
     this.rendering_queued = false
     this.pendingDeletes = new Array()
+    this.pendingAfterRender = new Array()
 
     // Expose the conditional so that if the `foreach` data is empty, successive
     // 'else' bindings will appear.
@@ -230,8 +241,10 @@ export class ForEachBinding extends AsyncBindingHandler {
   processQueue() {
     const isEmpty = !unwrap(this.data).length
     let lowestIndexChanged = MAX_LIST_SIZE
+    const moves = this.computeMoves(unwrap(this.data) || [])
 
     this.startQueueFlush()
+    this.fireMoveCallback(this.beforeMove, moves, 'oldIndex')
 
     arrayForEach(this.changeQueue, changeItem => {
       if (typeof changeItem.index === 'number') {
@@ -247,6 +260,8 @@ export class ForEachBinding extends AsyncBindingHandler {
       this.updateIndexes(lowestIndexChanged)
     }
 
+    this.fireMoveCallback(this.afterMove, moves, 'newIndex')
+    this.flushPendingAfterRender()
     this.endQueueFlush()
     this.changeQueue = new Array()
 
@@ -254,6 +269,74 @@ export class ForEachBinding extends AsyncBindingHandler {
     if (isEmpty !== !this.isNotEmpty()) {
       this.isNotEmpty(!isEmpty)
     }
+  }
+
+  // Detect items that remain in the new array but at a different index than in
+  // firstLastNodesList. Only compute if any move callback is registered.
+  computeMoves(newValues: any[]): { value: any; oldIndex: number; newIndex: number }[] {
+    if (typeof this.beforeMove !== 'function' && typeof this.afterMove !== 'function') {
+      return []
+    }
+    const oldByValue = new Map<any, number[]>()
+    this.firstLastNodesList.forEach((entry, oldIndex) => {
+      const list = oldByValue.get(entry.value) || []
+      list.push(oldIndex)
+      oldByValue.set(entry.value, list)
+    })
+    const moves: { value: any; oldIndex: number; newIndex: number }[] = []
+    newValues.forEach((value, newIndex) => {
+      const list = oldByValue.get(value)
+      if (!list || list.length === 0) {
+        return
+      }
+      const oldIndex = list.shift()!
+      if (oldIndex !== newIndex) {
+        moves.push({ value, oldIndex, newIndex })
+      }
+    })
+    return moves
+  }
+
+  fireMoveCallback(
+    callback: any,
+    moves: { value: any; oldIndex: number; newIndex: number }[],
+    lookupKey: 'oldIndex' | 'newIndex'
+  ) {
+    if (typeof callback !== 'function' || moves.length === 0) {
+      return
+    }
+    arrayForEach(moves, move => {
+      const entry = this.firstLastNodesList[move[lookupKey]]
+      if (!entry) {
+        return
+      }
+      arrayForEach(this.getNodesForEntry(entry), node => {
+        callback(node, move.newIndex, move.value)
+      })
+    })
+  }
+
+  getNodesForEntry(entry: { first: Node; last: Node }) {
+    const result: Node[] = []
+    let ptr: Node | null = entry.first
+    const last = entry.last
+    result.push(ptr)
+    while (ptr && ptr !== last) {
+      ptr = ptr.nextSibling
+      if (ptr) {
+        result.push(ptr)
+      }
+    }
+    return result
+  }
+
+  flushPendingAfterRender() {
+    if (typeof this.afterRender === 'function') {
+      arrayForEach(this.pendingAfterRender, item => {
+        this.afterRender(item.nodes, item.value)
+      })
+    }
+    this.pendingAfterRender = new Array()
   }
 
   /**
@@ -306,10 +389,10 @@ export class ForEachBinding extends AsyncBindingHandler {
     }
   }
 
-  updateFirstLastNodesList(index, children) {
+  updateFirstLastNodesList(index, children, value) {
     const first = children[0]
     const last = children[children.length - 1]
-    this.firstLastNodesList.splice(index, 0, { first, last })
+    this.firstLastNodesList.splice(index, 0, { first, last, value })
   }
 
   // Process a changeItem with {status: 'added', ...}
@@ -327,16 +410,17 @@ export class ForEachBinding extends AsyncBindingHandler {
       const pendingDelete = this.getPendingDeleteFor(valuesToAdd[i])
       if (pendingDelete && pendingDelete.nodesets.length) {
         children = pendingDelete.nodesets.pop()
-        this.updateFirstLastNodesList(index + i, children)
+        this.updateFirstLastNodesList(index + i, children, valuesToAdd[i])
       } else {
         const templateClone = this.templateNode.cloneNode(true)
         children = virtualElements.childNodes(templateClone)
-        this.updateFirstLastNodesList(index + i, children)
+        this.updateFirstLastNodesList(index + i, children, valuesToAdd[i])
 
         // Apply bindings first, and then process child nodes,
         // because bindings can add childnodes.
         const bindingResult = applyBindingsToDescendants(this.generateContext(valuesToAdd[i]), templateClone)
         asyncBindingResults.push(bindingResult)
+        this.pendingAfterRender.push({ nodes: Array.from(children), value: valuesToAdd[i] })
       }
 
       allChildNodes.push(...children)

--- a/packages/binding.foreach/verified-behaviors.json
+++ b/packages/binding.foreach/verified-behaviors.json
@@ -24,6 +24,10 @@
     {
       "statement": "Array mutation, reordering, duplicate values, `$index`, `as`, and `noIndex` are all exercised in spec coverage.",
       "specs": ["packages/binding.foreach/spec/eachBehavior.ts"]
+    },
+    {
+      "statement": "`foreach` supports `afterRender(nodes, value)`, `beforeMove(node, newIndex, value)`, and `afterMove(node, newIndex, value)` lifecycle callbacks in addition to the existing batch-shaped `afterAdd` and `beforeRemove` callbacks.",
+      "specs": ["packages/binding.foreach/spec/eachBehavior.ts"]
     }
   ]
 }

--- a/tko.io/src/content/docs/bindings/foreach-binding.md
+++ b/tko.io/src/content/docs/bindings/foreach-binding.md
@@ -306,3 +306,12 @@ Full details:
    3. The moved array element
 
 For examples of `afterAdd` and `beforeRemove`, use CSS transitions or your own DOM removal logic.
+
+> **Note — reference build (`@tko/binding.foreach`) differences:**
+>
+> The reference build's `ForEachBinding` supports `afterRender`, `beforeMove`, and `afterMove` with the per-item `(node, index, value)` signature documented above. Its `afterAdd` and `beforeRemove` callbacks use a different, batch-oriented shape inherited from `knockout-foreach`:
+>
+>  * `afterAdd({ nodeOrArrayInserted, foreachInstance })` — called once per added batch (including the initial render), with the full array of inserted nodes.
+>  * `beforeRemove({ nodesToRemove, foreachInstance })` — called once per removed batch.
+>
+> `beforeRemove` in the reference build also accepts a **thenable return value**: if the callback returns a `Promise` (or any object with a `.then()` method), the nodes are removed automatically when the thenable resolves. This convenience is a tko extension and is **not part of the original Knockout `foreach` API** — Knockout's documented `beforeRemove` fires per node and always requires the callback to remove the DOM node itself. Code that relies on the thenable shortcut will not be portable to plain Knockout or to the knockout build (`@tko/build.knockout`), which follows the documented per-node contract.

--- a/tko.io/src/content/docs/bindings/foreach-binding.md
+++ b/tko.io/src/content/docs/bindings/foreach-binding.md
@@ -311,7 +311,7 @@ For examples of `afterAdd` and `beforeRemove`, use CSS transitions or your own D
 >
 > The reference build's `ForEachBinding` supports `afterRender`, `beforeMove`, and `afterMove` with the per-item `(node, index, value)` signature documented above. Its `afterAdd` and `beforeRemove` callbacks use a different, batch-oriented shape inherited from `knockout-foreach`:
 >
->  * `afterAdd({ nodeOrArrayInserted, foreachInstance })` — called once per added batch (including the initial render), with the full array of inserted nodes.
->  * `beforeRemove({ nodesToRemove, foreachInstance })` — called once per removed batch.
+> * `afterAdd({ nodeOrArrayInserted, foreachInstance })` — called once per added batch (including the initial render), with the full array of inserted nodes.
+> * `beforeRemove({ nodesToRemove, foreachInstance })` — called once per removed batch.
 >
 > `beforeRemove` in the reference build also accepts a **thenable return value**: if the callback returns a `Promise` (or any object with a `.then()` method), the nodes are removed automatically when the thenable resolves. This convenience is a tko extension and is **not part of the original Knockout `foreach` API** — Knockout's documented `beforeRemove` fires per node and always requires the callback to remove the DOM node itself. Code that relies on the thenable shortcut will not be portable to plain Knockout or to the knockout build (`@tko/build.knockout`), which follows the documented per-node contract.


### PR DESCRIPTION
## Summary

Closes #329.

Adds the documented `foreach` lifecycle callbacks that were missing from `ForEachBinding` in the reference build, without breaking the existing `afterAdd`/`beforeRemove` batch contract:

- **`afterRender(nodes, value)`** — fires once per item when a new nodeset is rendered from the template (initial render and later additions).
- **`beforeMove(node, newIndex, value)`** / **`afterMove(node, newIndex, value)`** — fire per retained node whose index changed; move detection compares the tracked `firstLastNodesList` entries against the current array values and only runs if at least one move callback is registered.
- **`afterAdd({ nodeOrArrayInserted, foreachInstance })`** and **`beforeRemove({ nodesToRemove, foreachInstance })`** are unchanged, including the tko-specific thenable-return shortcut for deferred node removal.
- Documentation (`foreach-binding.md` Note 8) now calls out the reference build's batch-shaped `afterAdd`/`beforeRemove` and the thenable extension as deviations from the original Knockout contract.

## Test plan

- [x] `bun run verify` (5395 tests pass, 0 failures)
- [x] New spec coverage:
  - `afterRender` fires for initial and added items with `(nodes, value)`
  - `beforeMove`/`afterMove` fire with `(node, newIndex, value)` when retained items shift
- [x] Existing `afterAdd`/`beforeRemove` tests continue to pass unchanged (batch signature + thenable removal)
- [x] `verified-behaviors.json` updated
- [x] Changeset added (`patch`, additive only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Foreach binding adds per-item lifecycle callbacks: afterRender (newly rendered items), beforeMove and afterMove (items that change position).

* **Documentation**
  * Foreach docs updated with per-item callback signatures, compatibility notes, and that beforeRemove may return a thenable (tko-specific).

* **Tests**
  * New tests cover afterRender, beforeMove, afterMove, move detection, and non-reactivity of observables read during afterRender.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->