### PR TITLE
chore: prep 4.1.0 — fix peer-dep cascade, shim removed utils API

### DIFF
--- a/.changeset/fix-jsx-clean-teardown-race.md
+++ b/.changeset/fix-jsx-clean-teardown-race.md
@@ -1,5 +1,5 @@
 ---
-"@tko/utils.jsx": patch
+"@tko/utils.jsx": minor
 ---
 
 Add `options.jsxCleanBatchSize` (default `1000`) controlling JSX node cleanup

--- a/.changeset/modernize-utils-dead-polyfills.md
+++ b/.changeset/modernize-utils-dead-polyfills.md
@@ -1,28 +1,34 @@
 ---
-"@tko/utils": minor
+"@tko/utils": patch
 "@tko/utils.parser": patch
 "@tko/observable": patch
 "@tko/binding.core": patch
 "@tko/binding.foreach": patch
 "@tko/computed": patch
 "@tko/lifecycle": patch
-"@tko/builder": minor
+"@tko/builder": patch
 ---
 
 Drop dead polyfill probes from `@tko/utils`
 
 Removes runtime feature detection for capabilities that all supported runtimes
-(modern browsers, Node, Bun, happy-dom) already expose unconditionally:
+(modern browsers, Node, Bun, happy-dom) already expose unconditionally. The
+public API surface is preserved as one-line passthroughs in
+`packages/utils/src/compat.ts` so existing consumers continue to work; these
+shims are slated for removal in the next major.
 
 - `functionSupportsLengthOverwrite` + `overwriteLengthPropertyIfSupported` —
   `Object.defineProperty(fn, 'length', …)` has worked since IE9. Call sites
-  in `@tko/observable` now invoke `Object.defineProperty` directly.
+  in `@tko/observable` now invoke `Object.defineProperty` directly. The
+  internal probe is gone; `overwriteLengthPropertyIfSupported` is preserved
+  on `@tko/utils` exports as an inline `Object.defineProperty` call.
 - `useSymbols` + `createSymbolOrString` — `Symbol` is always defined; call
-  sites now use `Symbol(identifier)` directly. `createSymbolOrString` is no
-  longer exposed on `ko.utils` (public API removal — minor bump for
-  `@tko/utils` and `@tko/builder`).
-- `stringTrim` + `stringStartsWith` — removed; call sites use
-  `String(value ?? '').trim()` / `value.startsWith(prefix)` inline.
+  sites now use `Symbol(identifier)` directly. `createSymbolOrString` is
+  preserved as `s => Symbol(s)` on both `@tko/utils` exports and
+  `ko.utils.createSymbolOrString`.
+- `stringTrim` + `stringStartsWith` — call sites use `String(value ?? '')
+  .trim()` / `value.startsWith(prefix)` inline. Both names remain exported
+  from `@tko/utils` as inline passthroughs.
 - `toggleDomNodeCssClass` SVGAnimatedString fallback — `classList` is
   available on every supported `Element` (including SVG since SVG2).
 - `parseJson` no longer routes through `stringTrim`; it trims inline when the
@@ -31,3 +37,7 @@ Removes runtime feature detection for capabilities that all supported runtimes
 `packages/utils.parser/src/preparse.ts` also guards `str.match(bindingToken)`
 against the `null` return case using `?? []` — previously relied on the match
 never returning `null` for the transformed input.
+
+Patch-level for all packages: zero observable surface change for consumers
+not reaching into internal probes (`useSymbols`, `functionSupportsLengthOverwrite`),
+which had no monorepo callers.

--- a/bun.lock
+++ b/bun.lock
@@ -76,9 +76,6 @@
         "@tko/provider": "^4.0.1",
         "@tko/utils": "^4.0.1",
       },
-      "peerDependencies": {
-        "@tko/binding.foreach": "^4.0.1",
-      },
     },
     "packages/binding.component": {
       "name": "@tko/binding.component",
@@ -130,9 +127,6 @@
         "@tko/observable": "^4.0.1",
         "@tko/utils": "^4.0.1",
       },
-      "peerDependencies": {
-        "@tko/binding.if": "^4.0.1",
-      },
     },
     "packages/builder": {
       "name": "@tko/builder",
@@ -169,9 +163,6 @@
       "dependencies": {
         "@tko/computed": "^4.0.1",
         "@tko/utils": "^4.0.1",
-      },
-      "peerDependencies": {
-        "@tko/observable": "^4.0.1",
       },
     },
     "packages/observable": {
@@ -276,13 +267,6 @@
         "@tko/observable": "^4.0.1",
         "@tko/utils": "^4.0.1",
       },
-      "peerDependencies": {
-        "@tko/bind": "^4.0.1",
-        "@tko/binding.core": "^4.0.1",
-        "@tko/computed": "^4.0.1",
-        "@tko/provider.multi": "^4.0.1",
-        "@tko/provider.virtual": "^4.0.1",
-      },
     },
     "packages/utils.functionrewrite": {
       "name": "@tko/utils.functionrewrite",
@@ -306,11 +290,6 @@
       "dependencies": {
         "@tko/observable": "^4.0.1",
         "@tko/utils": "^4.0.1",
-      },
-      "peerDependencies": {
-        "@tko/bind": "^4.0.1",
-        "@tko/binding.core": "^4.0.1",
-        "@tko/provider.databind": "^4.0.1",
       },
     },
   },

--- a/packages/bind/package.json
+++ b/packages/bind/package.json
@@ -11,9 +11,6 @@
     "@tko/utils": "^4.0.1",
     "@tko/builder": "^4.0.1"
   },
-  "peerDependencies": {
-    "@tko/binding.foreach": "^4.0.1"
-  },
   "files": [
     "dist/"
   ],

--- a/packages/binding.template/package.json
+++ b/packages/binding.template/package.json
@@ -29,9 +29,6 @@
     "@tko/observable": "^4.0.1",
     "@tko/utils": "^4.0.1"
   },
-  "peerDependencies": {
-    "@tko/binding.if": "^4.0.1"
-  },
   "licenses": [
     {
       "type": "MIT",

--- a/packages/builder/src/Builder.ts
+++ b/packages/builder/src/Builder.ts
@@ -17,6 +17,7 @@ import {
   cleanNode,
   cloneNodes,
   compareArrays,
+  createSymbolOrString,
   domData,
   extend,
   memoization,
@@ -115,6 +116,7 @@ export type Utils = {
   arrayRemoveItem: typeof arrayRemoveItem
   cloneNodes: typeof cloneNodes
   compareArrays: typeof compareArrays
+  createSymbolOrString: typeof createSymbolOrString
   domData: typeof domData
   domNodeDisposal: typeof domNodeDisposal
   extend: typeof extend
@@ -147,6 +149,7 @@ const utils: Utils = {
   arrayRemoveItem,
   cloneNodes,
   compareArrays,
+  createSymbolOrString,
   domData,
   domNodeDisposal,
   extend,

--- a/packages/lifecycle/package.json
+++ b/packages/lifecycle/package.json
@@ -3,6 +3,7 @@
   "module": "dist/index.js",
   "dependencies": {
     "@tko/computed": "^4.0.1",
+    "@tko/observable": "^4.0.1",
     "@tko/utils": "^4.0.1"
   },
   "files": [

--- a/packages/lifecycle/package.json
+++ b/packages/lifecycle/package.json
@@ -5,9 +5,6 @@
     "@tko/computed": "^4.0.1",
     "@tko/utils": "^4.0.1"
   },
-  "peerDependencies": {
-    "@tko/observable": "^4.0.1"
-  },
   "files": [
     "dist/"
   ],

--- a/packages/utils.component/package.json
+++ b/packages/utils.component/package.json
@@ -12,13 +12,6 @@
     "@tko/observable": "^4.0.1",
     "@tko/utils": "^4.0.1"
   },
-  "peerDependencies": {
-    "@tko/bind": "^4.0.1",
-    "@tko/binding.core": "^4.0.1",
-    "@tko/computed": "^4.0.1",
-    "@tko/provider.multi": "^4.0.1",
-    "@tko/provider.virtual": "^4.0.1"
-  },
   "homepage": "https://tko.io",
   "licenses": [
     {

--- a/packages/utils.parser/package.json
+++ b/packages/utils.parser/package.json
@@ -11,11 +11,6 @@
     "@tko/observable": "^4.0.1",
     "@tko/utils": "^4.0.1"
   },
-  "peerDependencies": {
-    "@tko/bind": "^4.0.1",
-    "@tko/binding.core": "^4.0.1",
-    "@tko/provider.databind": "^4.0.1"
-  },
   "homepage": "https://tko.io",
   "licenses": [
     {

--- a/packages/utils/src/compat.ts
+++ b/packages/utils/src/compat.ts
@@ -22,16 +22,13 @@ export function stringTrim(value: any): string {
  * @deprecated Use `String.prototype.startsWith` directly. Will be removed in a future major.
  */
 export function stringStartsWith(value: string, prefix: string): boolean {
-  return value.startsWith(prefix)
+  return (value ?? '').startsWith(prefix)
 }
 
 /**
  * @deprecated Use `Object.defineProperty(fn, 'length', descriptor)` directly.
  * Will be removed in a future major.
  */
-export function overwriteLengthPropertyIfSupported(
-  fn: Function,
-  descriptor: PropertyDescriptor,
-): void {
+export function overwriteLengthPropertyIfSupported(fn: Function, descriptor: PropertyDescriptor): void {
   Object.defineProperty(fn, 'length', descriptor)
 }

--- a/packages/utils/src/compat.ts
+++ b/packages/utils/src/compat.ts
@@ -1,20 +1,34 @@
 // Compat passthroughs preserving the public @tko/utils API after the
 // post-Symbol/post-IE9 polyfill removals. Each function delegates to a
 // native API; kept so consumers importing these names continue to work.
-// Removal slated for the next major version.
+// All entries here are slated for removal in the next major version.
 
+/**
+ * @deprecated Use `Symbol(identifier)` directly. Will be removed in a future major.
+ */
 export function createSymbolOrString(identifier: string): symbol {
   return Symbol(identifier)
 }
 
+/**
+ * @deprecated Use `String(value ?? '').trim()` directly (or `String.prototype.trim`
+ * when the input is known to be a string). Will be removed in a future major.
+ */
 export function stringTrim(value: any): string {
   return String(value ?? '').trim()
 }
 
+/**
+ * @deprecated Use `String.prototype.startsWith` directly. Will be removed in a future major.
+ */
 export function stringStartsWith(value: string, prefix: string): boolean {
   return value.startsWith(prefix)
 }
 
+/**
+ * @deprecated Use `Object.defineProperty(fn, 'length', descriptor)` directly.
+ * Will be removed in a future major.
+ */
 export function overwriteLengthPropertyIfSupported(
   fn: Function,
   descriptor: PropertyDescriptor,

--- a/packages/utils/src/compat.ts
+++ b/packages/utils/src/compat.ts
@@ -1,0 +1,23 @@
+// Compat passthroughs preserving the public @tko/utils API after the
+// post-Symbol/post-IE9 polyfill removals. Each function delegates to a
+// native API; kept so consumers importing these names continue to work.
+// Removal slated for the next major version.
+
+export function createSymbolOrString(identifier: string): symbol {
+  return Symbol(identifier)
+}
+
+export function stringTrim(value: any): string {
+  return String(value ?? '').trim()
+}
+
+export function stringStartsWith(value: string, prefix: string): boolean {
+  return value.startsWith(prefix)
+}
+
+export function overwriteLengthPropertyIfSupported(
+  fn: Function,
+  descriptor: PropertyDescriptor,
+): void {
+  Object.defineProperty(fn, 'length', descriptor)
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -6,6 +6,7 @@
 
 export * from './array'
 export * from './async'
+export * from './compat'
 export * from './error'
 export * from './object'
 export * from './string'


### PR DESCRIPTION
## Summary

A previous release attempt minted **v5.0.0** because Changesets promoted minor bumps to major across the 27-package fixed group. The trigger wasn't the change content — it was a chain of intra-fixed-group `peerDependencies` (mostly spec-only or type-only) that caused any minor in the group to cascade to a major for every dependent.

This PR lands the next release as **4.1.0 minor** by fixing the cascade and restoring the one removed `ko.utils` identifier as a `@deprecated` passthrough.

## What changed

### 1. Drop spurious intra-fixed-group `peerDependencies` (`55360445`)

Verified each by grepping the depender's `src/` for runtime imports of the peer:

| Depender | Peer(s) | Real use |
|---|---|---|
| `@tko/bind` | `@tko/binding.foreach` | spec only |
| `@tko/binding.template` | `@tko/binding.if` | spec only |
| `@tko/lifecycle` | `@tko/observable` | `import type` (erased) |
| `@tko/utils.component` | bind, binding.core, computed, provider.multi, provider.virtual | spec only |
| `@tko/utils.parser` | bind, binding.core, provider.databind | spec only |

Workspace-resolved specs don't need a devDep declaration in this Bun monorepo. Lifecycle's `import type { Observable }` is erased post-compilation; consumers using the type already have `@tko/observable` via their own deps.

### 2. Restore removed `@tko/utils` API as `@deprecated` compat shims (`cc5ddf19`, `52b00839`)

Commits `6f4b5f2b` and `517ddc14` removed four public identifiers. Each was a trivial wrapper around a now-universal native API; restoring them as one-line passthroughs preserves the public surface at zero behavior cost.

New `packages/utils/src/compat.ts` (each `@deprecated` with the standardized replacement called out for IDE hover):

- `createSymbolOrString(id) => Symbol(id)`
- `stringTrim(v) => String(v ?? '').trim()`
- `stringStartsWith(s, p) => s.startsWith(p)`
- `overwriteLengthPropertyIfSupported(fn, d) => Object.defineProperty(fn, 'length', d)`

`@tko/builder` re-wires `createSymbolOrString` into the `Utils` type, the `utils` object literal, and the import list so `ko.utils.createSymbolOrString` continues to resolve. Removal is scheduled for the next major.

Internal probes (`useSymbols`, `functionSupportsLengthOverwrite`) had no monorepo callers and stay removed.

### 3. Changeset adjustments

- `modernize-utils-dead-polyfills`: `@tko/utils` and `@tko/builder` demoted from minor → patch. Description updated to call out the passthrough preservation.
- `fix-jsx-clean-teardown-race`: `@tko/utils.jsx` promoted from patch → minor. Adding `options.jsxCleanBatchSize` is a public option — minor by strict semver. Cascades the fixed group to 4.1.0.

## Verification

- `bun run build` clean across all 27 packages
- `bun run tsc` clean
- `bunx @changesets/cli status --verbose` reports **all 27 fixed-group packages → 4.1.0 minor, zero majors**
- `createSymbolOrString` confirmed end-to-end:
  - in source `packages/utils/src/compat.ts`
  - in compiled `packages/utils/dist/compat.js`
  - in bundled `builds/reference/dist/browser.js` and `builds/knockout/dist/browser.js`
  - in the `ko.utils` object literal at the same site

## Release path

After merge:

```bash
bunx @changesets/cli version
bunx @changesets/cli publish
```

## Test plan

- [x] `bun run build`
- [x] `bun run tsc`
- [x] `bunx @changesets/cli status --verbose` shows 4.1.0 minor cascade
- [x] grep verification of every dropped peer-dep
- [x] dist artifacts contain the four shims
- [ ] full `bun run verify` (browser tests) — please run on CI before merge

https://claude.ai/code/session_01Jnv99bwWtFWFmsyL7A2cJv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jnv99bwWtFWFmsyL7A2cJv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new compatibility utility functions to the utils package, including string trimming, prefix matching, and function property configuration tools.
  * Exposed symbol and string creation utilities within the builder framework for public use.

* **Chores**
  * Streamlined package dependency configuration by removing peer dependency requirements across multiple packages, providing greater flexibility in dependency management and package composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->