### PR TITLE
docs(tko.io): make landing version pill dynamic

### DIFF
--- a/tko.io/src/content/docs/index.mdx
+++ b/tko.io/src/content/docs/index.mdx
@@ -4,8 +4,9 @@ description: Modern Knockout — reactive data binding and UI templating with ze
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import pkg from '../../../../builds/knockout/package.json';
 
-<a class="landing-version" href="https://github.com/knockout/tko/releases">TKO v4.0.1 is here &rarr;</a>
+<a class="landing-version" href="https://github.com/knockout/tko/releases">TKO v{pkg.version} is here &rarr;</a>
 
 <div class="landing-hero">
   <h2>TKO</h2>


### PR DESCRIPTION
## Summary

The landing pill on tko.io still read **`TKO v4.0.1 is here`** after 4.1.0 shipped, while the header version badge (already package.json-driven) correctly showed `v4.1.0`. The pill was hardcoded — exactly the kind of admin-tax that runs against the dark-factory thesis.

Mirror the `Header.astro` pattern: import `builds/knockout/package.json` and interpolate `pkg.version` into the pill text. One canonical source for "what version is live"; no per-release MDX edit required.

## Diff

```diff
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import pkg from '../../../../builds/knockout/package.json';

-<a class="landing-version" href="...">TKO v4.0.1 is here &rarr;</a>
+<a class="landing-version" href="...">TKO v{pkg.version} is here &rarr;</a>
```

Two-line change.

## Verification

- `bun run build` in `tko.io/` — clean (66 pages built in 18.71s)
- `dist/index.html` renders `TKO v4.1.0 is here →` for the pill and `v4.1.0` for the header badge — both pointing at the right release tag
- Single source: when 4.2.0 ships, `builds/knockout/package.json` flips, both surfaces update on the next docs build

## Test plan

- [x] Astro build passes with the dynamic import
- [x] Rendered HTML shows the correct version
- [ ] Deploy preview shows the same on the live site

https://claude.ai/code/session_01Jnv99bwWtFWFmsyL7A2cJv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jnv99bwWtFWFmsyL7A2cJv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Documentation landing page now automatically displays the current TKO release version, ensuring accuracy without manual updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->