### PR TITLE
fix: resolve async completion in ConditionalBindingHandler

### DIFF
--- a/.changeset/fix-conditional-binding-async-completion.md
+++ b/.changeset/fix-conditional-binding-async-completion.md
@@ -1,0 +1,5 @@
+---
+"@tko/binding.if": patch
+---
+
+Fix async completion in ConditionalBindingHandler: call completeBinding() for non-rendering branches (if: false, ifnot: true, with: null) and correctly await async descendants via completionPromise instead of awaiting the BindingResult directly.

--- a/packages/bind/spec/bindingCompletionPromiseBehavior.ts
+++ b/packages/bind/spec/bindingCompletionPromiseBehavior.ts
@@ -194,4 +194,14 @@ describe('Binding Application Promise', function () {
       '<div><span data-bind="template: {foreach: y}"><i data-bind="foreach: z"><i data-bind="text: $data">a</i><i data-bind="text: $data">b</i></i></span></div>'
     )
   })
+
+  it('completes with if binding containing async descendants', async function () {
+    const div = document.createElement('div')
+    div.innerHTML = '<span data-bind="if: true"><i data-bind="async: x"></i></span>'
+    const x = observable(false)
+    const abr = applyBindings({ x }, div)
+    expect(x()).to.equal(false)
+    await abr
+    expect(x()).to.equal(true)
+  })
 })

--- a/packages/binding.if/spec/elseBehaviors.ts
+++ b/packages/binding.if/spec/elseBehaviors.ts
@@ -271,4 +271,10 @@ describe('Else binding', function () {
     y(false)
     expect(testNode.innerText).to.equal('x')
   })
+
+  it('Should resolve applyBindings promise when if is false with an else sibling chain', async function () {
+    testNode.innerHTML = "<i data-bind='if: x'>a</i>" + "<b data-bind='else'>b</b>"
+    await applyBindings({ x: false }, testNode)
+    expect(testNode.innerText).to.equal('b')
+  })
 })

--- a/packages/binding.if/spec/ifBehaviors.ts
+++ b/packages/binding.if/spec/ifBehaviors.ts
@@ -155,4 +155,10 @@ describe('Binding: If', function () {
     expect(callbacks).to.equal(2)
     expectContainText(testNode.childNodes[0], 'hello')
   })
+
+  it('Should resolve applyBindings promise when condition is false with no else branch', async function () {
+    testNode.innerHTML = "<div data-bind='if: false'><span data-bind='text: $data'></span></div>"
+    await applyBindings({}, testNode)
+    expect(testNode.childNodes[0].childNodes.length).to.equal(0)
+  })
 })

--- a/packages/binding.if/spec/ifnotBehaviors.ts
+++ b/packages/binding.if/spec/ifnotBehaviors.ts
@@ -113,4 +113,10 @@ describe('Binding: Ifnot', function () {
     expect(callbacks).to.equal(2)
     expectContainText(testNode.childNodes[0], 'hello')
   })
+
+  it('Should resolve applyBindings promise when condition is truthy with no else branch', async function () {
+    testNode.innerHTML = "<div data-bind='ifnot: true'><span data-bind='text: $data'></span></div>"
+    await applyBindings({}, testNode)
+    expect(testNode.childNodes[0].childNodes.length).to.equal(0)
+  })
 })

--- a/packages/binding.if/spec/withBehaviors.ts
+++ b/packages/binding.if/spec/withBehaviors.ts
@@ -406,4 +406,10 @@ describe('Binding: With', function () {
     expect(callbacks).to.equal(2)
     expectContainText(testNode.childNodes[0], 'new child')
   })
+
+  it('Should resolve applyBindings promise when value is null with no else branch', async function () {
+    testNode.innerHTML = "<div data-bind='with: item'><span data-bind='text: $data'></span></div>"
+    await applyBindings({ item: null }, testNode)
+    expect(testNode.childNodes[0].childNodes.length).to.equal(0)
+  })
 })

--- a/packages/binding.if/src/ConditionalBindingHandler.ts
+++ b/packages/binding.if/src/ConditionalBindingHandler.ts
@@ -76,6 +76,7 @@ export default class ConditionalBindingHandler extends AsyncBindingHandler {
       this.renderAndApplyBindings(this.ifElseNodes.elseNodes)
     } else {
       virtualElements.emptyNode(this.$element)
+      this.completeBinding()
     }
   }
 
@@ -83,7 +84,12 @@ export default class ConditionalBindingHandler extends AsyncBindingHandler {
     if (!useOriginalNodes) {
       virtualElements.setDomNodeChildren(this.$element, cloneNodes(nodes))
     }
-    const bound = await applyBindingsToDescendants(this.bindingContext, this.$element)
+    const bound = applyBindingsToDescendants(this.bindingContext, this.$element)
+    if (bound.isSync) {
+      this.bindingCompletion = bound
+    } else {
+      await bound.completionPromise
+    }
     this.completeBinding(bound)
   }
 


### PR DESCRIPTION
## Summary

Fixes two bugs in `ConditionalBindingHandler` identified in [typescript-code-review-findings-5.md](https://github.com/Auge19/tko/blob/pc/review_skill_and_demo_plans/plans/typescript-code-review-findings-5.md) (Critical Finding 1).

- **Non-rendering branches never resolved**: `if: false`, `ifnot: true`, and `with: null` all hit the empty-branch path in `render()` without calling `completeBinding()`, leaving the `AsyncBindingHandler` promise permanently unresolved. Any `await applyBindings(...)` would hang indefinitely.

- **Premature completion with async descendants**: `renderAndApplyBindings` used `await applyBindingsToDescendants(...)`, but that function returns a `BindingResult` synchronously — not a Promise. The `await` resolved immediately without waiting for async child bindings to finish. Fix follows the `DescendantBindingHandler` pattern: call without `await`, use `bound.completionPromise` when `!bound.isSync`, and short-circuit `this.bindingCompletion = bound` for the sync case so the binding isn't unnecessarily tracked as async.

## Test plan

- [x] `bun run build` passes
- [x] `bunx vitest run packages/binding.if` — new regression tests for `if: false`, `ifnot: true`, `with: null` completion
- [x] `bunx vitest run packages/bind/spec/bindingCompletionPromiseBehavior.ts` — new test for `if: true` with async descendants
- [x] `bunx vitest run` — full suite (290 files, no regressions)