### PR TITLE
chore(deps): add 2-day cooldown to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,14 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 10
+    # Hold version bumps for 2 days after publish so a freshly compromised
+    # release has time to be yanked / flagged before Dependabot opens the
+    # PR. Security updates ignore cooldown and ship immediately, so CVE
+    # response time is unaffected. The dark-factory thesis: a low-level
+    # framework with an unknown audience cannot afford supply-chain blast
+    # radius from same-day automated dep bumps.
+    cooldown:
+      default-days: 2
     ignore:
       # package will be removed
       - dependency-name: "*jasmine*"
@@ -32,3 +40,5 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 2


### PR DESCRIPTION
## Summary

Adds a 2-day `cooldown:` to both Dependabot ecosystems (npm,
github-actions). Newly-published releases sit for 48h before
Dependabot opens a PR, so a compromised release has time to be
yanked or flagged. Security updates bypass cooldown by design — CVE
response time is unchanged.

Closes a gap from
[`plans/2026-04-16-dark-factory.md`](../blob/main/plans/2026-04-16-dark-factory.md)
("Dependency updates: Renovate/Dependabot with 48h
minimumReleaseAge"). Dependabot gained the equivalent `cooldown:`
block in 2025, so this keeps a single tool.

## Why now

Per `AGENTS.md` ("Low-level framework with an unknown audience"),
supply-chain blast radius for a published framework is the kind of
asymmetric risk dark-factory infrastructure should mechanically gate
rather than rely on vigilance for. Same-day automated dep PRs are the
class of automation that compounds risk; a 2-day window is the cheapest
fix.

## Test plan

- [x] YAML validates locally (`.github/dependabot.yml` parsed by Edit
      tool; structure follows GitHub's documented schema)
- [ ] First Monday after merge: confirm the weekly Dependabot run
      respects the cooldown (PRs reference releases ≥ 2 days old)
- [ ] Confirm a security update PR still opens immediately if one is
      raised (cooldown does not apply to security updates)

## Adversarial review

Run as a fresh subagent against the diff + claim. Three findings,
each verified against upstream `dependabot/dependabot-core` issues:

1. **#13691** — fast-releasing GitHub Actions can be trapped when
   cooldown's filter only checks the latest release. Verified: the
   actions this repo uses (`actions/checkout`, `oven-sh/setup-bun`,
   `actions/setup-node`, `changesets/action`, `actions/upload-artifact`)
   all release at monthly+ cadence and are not at risk under a 2-day
   window. Worth revisiting if we add a fast-release action later.
2. **#13979** — narrow implementation defect where security updates
   were observed running with cooldown applied. The documented design
   (security bypasses cooldown) is unchanged. Claim stands.
3. **Cooldown + `groups:` interaction** — per GitHub docs, a dep within
   cooldown is *skipped* from the group PR; the group PR still opens
   with the remaining deps. Not a blocker.

Resolved: change kept as-is.

## Out of scope

- Other dark-factory gaps (bundle-size gate, coverage delta comment,
  changeset-presence check) — separate PRs.
- `semver-major-days` / `semver-minor-days` / `semver-patch-days`
  granularity — start uniform at 2 days, tune later if any group
  shows a pattern that warrants it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GFtZhyYutreRGmsVQXTUDH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted automated dependency update scheduling to include a cooldown period between releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/knockout/tko/pull/385?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->