### PR TITLE
fix: use mapped bindingName in AttributeMustacheProvider

### DIFF
--- a/.changeset/fix-attribute-mustache-binding-name.md
+++ b/.changeset/fix-attribute-mustache-binding-name.md
@@ -2,4 +2,4 @@
 "@tko/provider.mustache": patch
 ---
 
-Fix AttributeMustacheProvider to use the mapped binding name (e.g. `css`) instead of the raw attribute name (e.g. `class`) when looking up and emitting a direct binding. In handler sets that register `css` but not a `class` alias, `class="{{ expr }}"` previously fell through to `attr.class` instead of activating the `css` binding handler. Also guards against non-string values in a custom `attributesBindingMap`.
+Fix AttributeMustacheProvider to use the mapped binding name (e.g. `css`) instead of the raw attribute name (e.g. `class`) when looking up and emitting a direct binding. In handler sets that register `css` but not a `class` alias, `class="{{ expr }}"` previously fell through to `attr.class` instead of activating the `css` binding handler.

--- a/.changeset/fix-attribute-mustache-binding-name.md
+++ b/.changeset/fix-attribute-mustache-binding-name.md
@@ -2,4 +2,4 @@
 "@tko/provider.mustache": patch
 ---
 
-Fix AttributeMustacheProvider to use the mapped binding name (e.g. `css`) instead of the raw attribute name (e.g. `class`) when looking up and emitting a direct binding. Previously `class="{{ expr }}"` silently fell through to `attr.class` instead of activating the `css` binding handler.
+Fix AttributeMustacheProvider to use the mapped binding name (e.g. `css`) instead of the raw attribute name (e.g. `class`) when looking up and emitting a direct binding. In handler sets that register `css` but not a `class` alias, `class="{{ expr }}"` previously fell through to `attr.class` instead of activating the `css` binding handler. Also guards against non-string values in a custom `attributesBindingMap`.

--- a/.changeset/fix-attribute-mustache-binding-name.md
+++ b/.changeset/fix-attribute-mustache-binding-name.md
@@ -1,0 +1,5 @@
+---
+"@tko/provider.mustache": patch
+---
+
+Fix AttributeMustacheProvider to use the mapped binding name (e.g. `css`) instead of the raw attribute name (e.g. `class`) when looking up and emitting a direct binding. Previously `class="{{ expr }}"` silently fell through to `attr.class` instead of activating the `css` binding handler.

--- a/packages/provider.mustache/spec/attributeInterpolationSpec.ts
+++ b/packages/provider.mustache/spec/attributeInterpolationSpec.ts
@@ -167,6 +167,15 @@ describe('Attribute Interpolation Markup Provider', function () {
     expect(testNode.getAttribute('class')).to.equal('test')
   })
 
+  it('Should map class attribute to css binding', function () {
+    testNode.setAttribute('class', '{{expr}}')
+    const bindings: any[] = Array.from(provider.bindingObjects(testNode, ctxStub({ expr: 'active' })))
+    expect(bindings.length).to.equal(1)
+    expect(bindings[0]).to.have.property('css')
+    expect(bindings[0]).to.not.have.property('class')
+    expect(bindings[0]).to.not.have.property('attr.class')
+  })
+
   it('Should convert value and checked attributes to two-way bindings', function () {
     const input = document.createElement('input')
     input.type = 'checkbox'

--- a/packages/provider.mustache/src/AttributeMustacheProvider.ts
+++ b/packages/provider.mustache/src/AttributeMustacheProvider.ts
@@ -80,7 +80,7 @@ export default class AttributeMustacheProvider extends Provider {
 
   getPossibleDirectBinding(attrName: string | number) {
     const bindingName = this.ATTRIBUTES_BINDING_MAP[attrName]
-    return typeof bindingName === 'string' && this.bindingHandlers.get(bindingName)
+    return bindingName && this.bindingHandlers.get(bindingName)
   }
 
   *bindingObjects(node: Element, context: any) {

--- a/packages/provider.mustache/src/AttributeMustacheProvider.ts
+++ b/packages/provider.mustache/src/AttributeMustacheProvider.ts
@@ -80,7 +80,7 @@ export default class AttributeMustacheProvider extends Provider {
 
   getPossibleDirectBinding(attrName: string | number) {
     const bindingName = this.ATTRIBUTES_BINDING_MAP[attrName]
-    return bindingName && this.bindingHandlers.get(bindingName)
+    return typeof bindingName === 'string' && this.bindingHandlers.get(bindingName)
   }
 
   *bindingObjects(node: Element, context: any) {

--- a/packages/provider.mustache/src/AttributeMustacheProvider.ts
+++ b/packages/provider.mustache/src/AttributeMustacheProvider.ts
@@ -80,13 +80,14 @@ export default class AttributeMustacheProvider extends Provider {
 
   getPossibleDirectBinding(attrName: string | number) {
     const bindingName = this.ATTRIBUTES_BINDING_MAP[attrName]
-    return bindingName && this.bindingHandlers.get(attrName)
+    return bindingName && this.bindingHandlers.get(bindingName)
   }
 
   *bindingObjects(node: Element, context: any) {
     for (const [attrName, parts] of this.bindingParts(node, context)) {
       const bindingForAttribute = this.getPossibleDirectBinding(attrName)
-      const handler: string = bindingForAttribute ? attrName : `attr.${attrName}`
+      const bindingName = this.ATTRIBUTES_BINDING_MAP[attrName]
+      const handler: string = bindingForAttribute ? bindingName : `attr.${attrName}`
       const accessorFn = bindingForAttribute
         ? (...v: any) => this.partsTogether(parts, context, node, ...v)
         : (...v: any) => ({ [attrName]: this.partsTogether(parts, context, node, ...v) })


### PR DESCRIPTION
## Summary

Fixes #235.

`getPossibleDirectBinding` computed `bindingName` from `ATTRIBUTES_BINDING_MAP` (e.g. `'css'` for `'class'`) but then discarded it, calling `this.bindingHandlers.get(attrName)` — relying on the handler set having a `class` alias rather than using the explicit mapping. A companion bug in `bindingObjects` keyed the emitted binding by `attrName` (`'class'`) rather than the mapped `bindingName` (`'css'`).

### What was wrong

```typescript
// before
getPossibleDirectBinding(attrName) {
  const bindingName = this.ATTRIBUTES_BINDING_MAP[attrName]
  return bindingName && this.bindingHandlers.get(attrName)  // always used attrName
}

// bindingObjects
const handler = bindingForAttribute ? attrName : `attr.${attrName}`  // 'class', not 'css'
```

### What's fixed

```typescript
// after
getPossibleDirectBinding(attrName) {
  const bindingName = this.ATTRIBUTES_BINDING_MAP[attrName]
  return bindingName && this.bindingHandlers.get(bindingName)  // uses mapped name
}

// bindingObjects
const bindingName = this.ATTRIBUTES_BINDING_MAP[attrName]
const handler = bindingForAttribute ? bindingName : `attr.${attrName}`  // 'css'
```

### Scope note

In the default `coreBindings` setup both `css` and `class` are registered as aliases, so the old code worked incidentally via the alias. The fix matters most for custom handler sets that register `css` but not the `class` alias — in those configurations the old code fell through to `attr.class` entirely. Either way, using the mapped name is correct by design rather than by accident of alias coverage.

## Test plan

- [x] New regression test: `class="{{ expr }}"` produces a `css`-keyed binding, not `class` or `attr.class`
- [x] `bunx vitest run packages/provider.mustache` — 64 tests pass, 3 skipped (pre-existing)
- [x] Changeset added for `@tko/provider.mustache` (patch)

## Adversarial review

Conducted per AGENTS.md. Key finding: bug scope is narrower than the original issue implied (default config worked via the `class` alias). Fix is still correct — it uses the explicit mapping rather than relying on coincidental alias coverage. No regressions found.

https://claude.ai/code/session_01AddAhYQvoVaA19ephp56VY

---
_Generated by [Claude Code](https://claude.ai/code/session_01AddAhYQvoVaA19ephp56VY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Interpolated attributes like class="{{ expr }}" now resolve to their correct binding handlers instead of falling back to generic attribute handling.

* **Tests**
  * Added unit test coverage to ensure interpolated class attributes map to the intended binding and to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/knockout/tko/pull/387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->