### PR TITLE
docs(agents): add ko-* static-expression freeze gotcha to guide.md

### DIFF
--- a/tko.io/public/agents/guide.md
+++ b/tko.io/public/agents/guide.md
@@ -294,6 +294,7 @@ tko.applyBindings({ removeTodo: t => todos.remove(t) }, root)
 - **`dispose()` on computed/subscriptions** stops updates. After disposal, reading returns last cached value.
 - **HTML-producing computeds** should return `null` for empty output, not `false` or an empty fragment — bindings and JSX observers handle `null` cleanly.
 - **Binary HTML attributes** (`disabled`, `readonly`, `hidden`, `required`, `checked`, `selected`) omit the attribute when the value is `null`, `undefined`, or `false`. Use `|| undefined` in computeds to make "no attribute" explicit: `disabled={this.computed(() => shouldBeDisabled() || undefined)}`. Never return the string `"false"` — it keeps the attribute set.
+- **Pass the observable itself to `ko-*` attrs — not a called expression.** `ko-text={obs()}` calls `obs()` once at render time and gives TKO a static value; the DOM never updates after the initial render. Write `ko-text={obs}` (pass the observable). For derived expressions, hoist to a `ko.pureComputed`: `const label = ko.pureComputed(() => a() + b())`, then `ko-text={label}`.
 - **Prefer named computed variables over inline computeds in JSX.** A computed created inline in JSX is easier to accidentally recreate on each render than one bound to a class field or `const`.
 
 ## Testing


### PR DESCRIPTION
## What

Adds one bullet to the `## Gotchas` section of `tko.io/public/agents/guide.md`:

> **Pass the observable itself to `ko-*` attrs — not a called expression.** `ko-text={obs()}` calls `obs()` once at render time and gives TKO a static value; the DOM never updates after the initial render. Write `ko-text={obs}` (pass the observable). For derived expressions, hoist to a `ko.pureComputed`: `const label = ko.pureComputed(() => a() + b())`, then `ko-text={label}`.

## Why

`llms.txt` already warns *"Derived `ko-*` values must stay observable/computed — inline expressions freeze"* (line 47), but `guide.md`'s `## Gotchas` section had no equivalent entry — the two agent-facing docs were out of sync.

`NativeProvider.ts:44` confirms the behaviour:
```ts
const valueFn = isObservable(value) ? value : () => value
```
Non-observable values are wrapped as a static `() => value`, so `ko-text={obs()}` silently passes a plain string and the DOM never updates. This is a common, invisible mistake in agent-generated TSX.

## Scope

Single-line addition to one agent-facing doc file. No code changes, no API changes, no changeset needed.

https://claude.ai/code/session_018q2onX3ZYrxrr768L26hSH

---
_Generated by [Claude Code](https://claude.ai/code/session_018q2onX3ZYrxrr768L26hSH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification on proper usage of observables with JSX `ko-*` attributes to ensure reactive DOM updates work correctly, including guidance on handling derived expressions with computed properties.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/knockout/tko/pull/388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->