### PR TITLE
chore: remove unused Node setup step and dead ForEachBinding.ForEach getter

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,11 +24,6 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v6
 
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
-
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/packages/binding.foreach/src/foreach.ts
+++ b/packages/binding.foreach/src/foreach.ts
@@ -570,10 +570,6 @@ export class ForEachBinding extends AsyncBindingHandler {
     return true
   }
 
-  /* TODO: Remove; for legacy/testing */
-  static get ForEach() {
-    return this
-  }
   static get PENDING_DELETE_INDEX_SYM() {
     return PENDING_DELETE_INDEX_SYM
   }


### PR DESCRIPTION
Two small, independent cleanups proposed as part of the daily improvement cycle.

## Changes

### 1 — CI tooling (`deploy-docs.yml`)
Removes the `actions/setup-node@v6` step from the `Deploy Documentation` workflow. The job exclusively uses Bun (`bun install`, `bun run build`) — Node.js is never invoked. The step was dead weight adding ~15 s to every docs deploy with no effect.

### 2 — Dead code (`binding.foreach`)
Removes `ForEachBinding.ForEach`, a static getter that (a) was self-tagged `/* TODO: Remove; for legacy/testing */` and (b) simply returned `this`, making it a no-op alias for the class. Zero call sites exist in the repo.

## Test plan
- [ ] CI passes (no Node.js removal should affect the Bun-only deploy job)
- [ ] `bun run verify` green (no code-path change; getter was never called)

https://claude.ai/code/session_019rqkhDoG8ECW2RvgB6ZJEa

---
_Generated by [Claude Code](https://claude.ai/code/session_019rqkhDoG8ECW2RvgB6ZJEa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed legacy static getter from binding implementation
  * Added public access to pending-delete index symbol for advanced use cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/knockout/tko/pull/389?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->