### PR TITLE
docs: use bunx @playwright/cli in AGENTS.md and process.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ Builds: `@tko/build.knockout` (backwards-compatible) and
 - **Bun** — package manager and script runner. Install via [mise](https://mise.jdx.dev/): `mise install` (reads `.tool-versions`), or [bun.sh](https://bun.sh).
 - Use `bun install` instead of `npm install`; `bunx` instead of `npx`.
 - In repo scripts (`tko.io/scripts`, `tools/`), prefer native Bun APIs — `Bun.Glob`, `Bun.file`, `Bun.write`, `Bun.$` — over `node:fs`, the `glob` export from `node:fs/promises`, or ad-hoc `child_process`. Runtime is pinned by `.tool-versions`, so there's no Node-version portability concern.
-- Browser automation uses `bunx playwright <cmd>` via the repo's `playwright` dependency (not `npx playwright`, not the deprecated `playwright-cli` package).
+- Browser automation uses `bunx @playwright/cli <cmd>`.
 
 ## Build Commands
 

--- a/tko.io/public/agents/process.md
+++ b/tko.io/public/agents/process.md
@@ -74,10 +74,10 @@ Minimum (any docs change):
 
 For pages with runnable TSX examples, also run the headless Playwright flow:
 
-- Use `playwright-cli` in headless mode. Do not use headed/browser-stealing runs unless the user explicitly asks for them.
+- Use `bunx @playwright/cli` in headless mode. Do not use headed/browser-stealing runs unless the user explicitly asks for them.
 - Prefer a live Astro dev server on `127.0.0.1:4321` so markdown/plugin edits reload while you work (`bun run dev` in `tko.io/`).
 - Verify each `Open in Playground` button on the page; if a page has multiple TSX examples, check every one, not just the first.
-- Standard flow: `playwright-cli close-all`, `playwright-cli open http://127.0.0.1:4321/...`, inspect the snapshot for playground refs, click each button, switch to the playground tab, and confirm `[data-role="status"]` (shows "esbuild ready"), `[data-role="compile-time"]`, and `[data-role="error-bar"]`.
+- Standard flow: `bunx @playwright/cli close-all`, `bunx @playwright/cli open http://127.0.0.1:4321/...`, inspect the snapshot for playground refs, click each button, switch to the playground tab, and confirm `[data-role="status"]` (shows "esbuild ready"), `[data-role="compile-time"]`, and `[data-role="error-bar"]`.
 - Treat docs example work as incomplete until the emitted playground payload compiles cleanly on the live site.
 
 Generator-owned files: see the note at the top of this document under "Never ship docs that reference things that don't exist on the target branch."


### PR DESCRIPTION
Replace bare `playwright-cli` references with `bunx @playwright/cli` (the correct invocation for `@playwright/cli` v0.1.13). Also drop the prohibition framing from `AGENTS.md` — just state what to use.

https://claude.ai/code/session_01VXbxD98AzZ8pLfN2JmBeuE

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXbxD98AzZ8pLfN2JmBeuE)_