### PR TITLE
remove dead exports and stale polyfill comment

### DIFF
--- a/packages/filter.punches/spec/filterBehavior.ts
+++ b/packages/filter.punches/spec/filterBehavior.ts
@@ -6,13 +6,6 @@ import { filters } from '../dist'
 import { assert } from 'chai'
 
 declare let ko: KnockoutInstance
-/* can be remove https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.isarray
-if (!Array.isArray) {
-  Array.isArray = function (arg) {
-    return Object.prototype.toString.call(arg) === '[object Array]'
-  }
-}
-*/
 
 describe('Text filters preprocessor', function () {
   const filterPreprocessor = function (string) {

--- a/packages/provider.mustache/src/mustacheParser.ts
+++ b/packages/provider.mustache/src/mustacheParser.ts
@@ -69,7 +69,7 @@ class Text extends Interpolated {
 /**
  *          Interpolation Parsing
  */
-export function* innerParse(text: string) {
+function* innerParse(text: string) {
   const innerMatch = text.match(INNER_EXPRESSION)
   if (innerMatch) {
     const [pre, inner, post] = innerMatch.slice(1)
@@ -81,7 +81,7 @@ export function* innerParse(text: string) {
   }
 }
 
-export function* parseOuterMatch(outerMatch?: RegExpMatchArray | null) {
+function* parseOuterMatch(outerMatch?: RegExpMatchArray | null) {
   if (!outerMatch) {
     return
   }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Remove `export` from `innerParse` and `parseOuterMatch` in `packages/provider.mustache/src/mustacheParser.ts` — both are internal helpers that are never re-exported from `index.ts`; knip flags them as unused exports (issue #366)
- Delete the commented-out `Array.isArray` polyfill in `packages/filter.punches/spec/filterBehavior.ts` — author-marked "can be remove", zero runtime effect

## Test plan

- [ ] `bun run verify` passes (lint + typecheck + build + tests)
- [ ] `bun run knip` no longer reports `innerParse` or `parseOuterMatch` as unused exports

https://claude.ai/code/session_014spdok9YkrWpXWJ8kZ3C8H
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014spdok9YkrWpXWJ8kZ3C8H)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused commented code snippets from test files.
  * Refined internal function visibility to strengthen module encapsulation and reduce public API surface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/knockout/tko/pull/393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->