### PR TITLE
Daily improvements: biome schema, dead exports, stale FIXME, agent docs

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": {
     "ignoreUnknown": true,

--- a/packages/binding.if/src/ifUnless.ts
+++ b/packages/binding.if/src/ifUnless.ts
@@ -34,7 +34,6 @@ export class IfBindingHandler extends ConditionalBindingHandler {
 
     if (this.elseChainIsAlreadySatisfied) {
       shouldDisplay = false
-      // needsRefresh = isFirstRender || this.didDisplayOnLastUpdate FIXME
       this.completesElseChain(true)
     } else {
       this.completesElseChain(shouldDisplay)

--- a/packages/computed/src/proxy.ts
+++ b/packages/computed/src/proxy.ts
@@ -88,13 +88,13 @@ export function proxy(object) {
   return proxy
 }
 
-function getObservable(proxied, prop) {
+export function getObservable(proxied, prop) {
   return proxied[MIRROR_SYM][prop]
 }
-function peek(proxied, prop) {
+export function peek(proxied, prop) {
   return getObservable(proxied, prop).peek()
 }
-function isProxied(proxied) {
+export function isProxied(proxied) {
   return PROXY_SYM in proxied
 }
 

--- a/packages/computed/src/proxy.ts
+++ b/packages/computed/src/proxy.ts
@@ -88,13 +88,13 @@ export function proxy(object) {
   return proxy
 }
 
-export function getObservable(proxied, prop) {
+function getObservable(proxied, prop) {
   return proxied[MIRROR_SYM][prop]
 }
-export function peek(proxied, prop) {
+function peek(proxied, prop) {
   return getObservable(proxied, prop).peek()
 }
-export function isProxied(proxied) {
+function isProxied(proxied) {
   return PROXY_SYM in proxied
 }
 

--- a/tko.io/public/agents/guide.md
+++ b/tko.io/public/agents/guide.md
@@ -54,6 +54,7 @@ Context variables inside foreach: $data, $parent, $root, $index (observable), $e
 
 Binding notes:
 - `textInput` binds an `<input>` or `<textarea>` with immediate two-way updates as the user types, pastes, drags, or accepts autofill. Prefer it over `value` when the model must update continuously.
+- `foreach` supports lifecycle callbacks as binding parameters: `afterRender(nodes, value)` fires after each item renders; `beforeMove(node, newIndex, value)` and `afterMove(node, newIndex, value)` fire during array reordering.
 
 ```html
 <input data-bind="textInput: query">


### PR DESCRIPTION
$(cat <<'EOF'
Four small, independent improvements from the daily tko improvement run.

## Changes

**Tooling (commit 1):** Sync `biome.json` `$schema` URL to `2.4.16` — `package.json` already resolves `@biomejs/biome` at `^2.4.16` but the schema URL was still pinned to `2.4.11`. IDE tooling reads this URL for rule completion hints.

**Dead code (commit 2):** Remove `export` from `getObservable`, `peek`, and `isProxied` in `packages/computed/src/proxy.ts` — these three symbols appear in knip's unused-export list (issue #366 Phase 6). They remain accessible as `proxy.getObservable`, `proxy.peek`, `proxy.isProxied` via the `Object.assign` on the line below. None are re-exported from the package's public `index.ts`.

**Bug fix (commit 3):** Delete the stale FIXME comment in `packages/binding.if/src/ifUnless.ts` — `this.didDisplayOnLastUpdate` does not exist anywhere in the codebase and `needsRefresh` was never returned from `renderStatus()`. Leftover from an incomplete refactor.

**Agent docs (commit 4):** Add `foreach` lifecycle callbacks to `tko.io/public/agents/guide.md` — PR #369 added `afterRender`, `beforeMove`, and `afterMove` to the `foreach` binding and the verified-behaviors contract, but the agent guide never mentioned them.

## Test plan

- [ ] `bun run verify` passes (lint + typecheck + build + tests)
- [ ] `bun run knip` shows 3 fewer unused-export warnings for `proxy.ts`
- [ ] `tko.io/public/agents/guide.md` diff matches proposal exactly

https://claude.ai/code/session_01Fyj4bnZT5kKUSDH6ehjKPj
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fyj4bnZT5kKUSDH6ehjKPj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Utility functions `getObservable`, `peek`, and `isProxied` are now accessed as properties on the `proxy` function rather than as separate named exports.

* **Documentation**
  * Added documentation for `foreach` binding lifecycle callbacks including `afterRender`, `beforeMove`, and `afterMove`.

* **Chores**
  * Updated build tool configuration to the latest schema version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->