### PR TITLE
docs(agents): complete packages table in glossary (13 → 27)

### DIFF
--- a/tko.io/public/agents/glossary.md
+++ b/tko.io/public/agents/glossary.md
@@ -50,14 +50,28 @@ TKO is a monorepo. Key packages:
 |---------|---------|
 | `@tko/observable` | Observables, computed, observable arrays |
 | `@tko/computed` | Computed/pure computed implementation |
+| `@tko/lifecycle` | Subscription and disposal tracking mixin |
 | `@tko/bind` | Binding application, binding context, binding handlers |
 | `@tko/binding.core` | Built-in bindings (text, visible, css, attr, etc.) |
 | `@tko/binding.foreach` | foreach binding implementation |
 | `@tko/binding.if` | if/ifnot/with/using control flow |
 | `@tko/binding.template` | Template rendering engine |
+| `@tko/binding.component` | Component binding for custom elements |
 | `@tko/utils` | DOM utilities, array helpers, tasks scheduler |
+| `@tko/utils.component` | Component registry, loaders, and ComponentABC base class |
+| `@tko/utils.functionrewrite` | Rewrites function expressions as arrow functions for binding |
+| `@tko/utils.jsx` | JSX/TSX rendering: createElement, Fragment, JsxObserver |
+| `@tko/utils.parser` | CSP-safe expression parser for data-bind attributes |
 | `@tko/provider` | Base provider class |
 | `@tko/provider.databind` | `data-bind` attribute provider |
+| `@tko/provider.attr` | Binds `ko-*` HTML attributes to binding handlers |
+| `@tko/provider.bindingstring` | Abstract base for binding string parsers |
+| `@tko/provider.component` | Binding provider for custom web component elements |
+| `@tko/provider.multi` | Combines multiple binding providers into one |
+| `@tko/provider.mustache` | Mustache-style `{{ }}` interpolation in HTML |
+| `@tko/provider.native` | Binding provider for values set directly on DOM nodes (JSX/TSX) |
+| `@tko/provider.virtual` | Binding provider for `<!-- ko -->` virtual elements |
 | `@tko/builder` | Assembles TKO instance from packages |
+| `@tko/filter.punches` | Knockout-punches expression filters for binding strings |
 | `@tko/build.knockout` | Backwards-compatible Knockout.js distribution |
 | `@tko/build.reference` | Modern recommended distribution |


### PR DESCRIPTION
## Summary

- Expands the `tko.io/public/agents/glossary.md` Packages table from 13 → 27 entries, covering every `@tko/*` package in the monorepo
- Adds 14 missing packages grouped by logical area: lifecycle, bindings, utils, providers, filters

**New rows added:**

| Package | Purpose |
|---------|---------|
| `@tko/lifecycle` | Subscription and disposal tracking mixin |
| `@tko/binding.component` | Component binding for custom elements |
| `@tko/utils.component` | Component registry, loaders, and ComponentABC base class |
| `@tko/utils.functionrewrite` | Rewrites function expressions as arrow functions for binding |
| `@tko/utils.jsx` | JSX/TSX rendering: createElement, Fragment, JsxObserver |
| `@tko/utils.parser` | CSP-safe expression parser for data-bind attributes |
| `@tko/provider.attr` | Binds `ko-*` HTML attributes to binding handlers |
| `@tko/provider.bindingstring` | Abstract base for binding string parsers |
| `@tko/provider.component` | Binding provider for custom web component elements |
| `@tko/provider.multi` | Combines multiple binding providers into one |
| `@tko/provider.mustache` | Mustache-style `{{ }}` interpolation in HTML |
| `@tko/provider.native` | Binding provider for values set directly on DOM nodes (JSX/TSX) |
| `@tko/provider.virtual` | Binding provider for `<!-- ko -->` virtual elements |
| `@tko/filter.punches` | Knockout-punches expression filters for binding strings |

## Why

The previous table left 14 packages undocumented, including `@tko/lifecycle` (referenced 7+ times in `guide.md`) and the full provider sub-family. An agent reading only the glossary had no import path or description for these packages and had to fall back to searching the codebase.

## Verification

- All 14 package directories confirmed present under `packages/`
- All npm names verified against each package's `package.json` `name` field
- All descriptions cross-checked against `package.json` description + `index.ts` exports
- Independent adversarial review found no errors

## Test plan

- [ ] `tko.io` Astro build succeeds (`bun run build` in `tko.io/`)
- [ ] No broken links or references introduced (pure table addition)

https://claude.ai/code/session_01YJFLWTNLq2tJvciHW4FEC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJFLWTNLq2tJvciHW4FEC5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the packages section in the glossary with additional package entries for improved reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->