### PR TITLE
Fix Parser.name() to treat '}' as a terminator for shorthand properties

### DIFF
--- a/packages/utils.parser/spec/parserBehaviors.ts
+++ b/packages/utils.parser/spec/parserBehaviors.ts
@@ -134,6 +134,41 @@ describe('the bindings parser', function () {
     assert.equal(bindings.attr().kv, 'Sam')
   })
 
+  describe('shorthand (ES6) object properties', function () {
+    it('parses a shorthand property immediately followed by }', function () {
+      const bindings = new Parser().parse('x:{a}', ctxStub({ a: 1 }))
+      assert.deepEqual(Object.keys(bindings.x()), ['a'])
+      assert.equal(bindings.x().a, 1)
+    })
+
+    it('parses multiple shorthand properties with no trailing comma', function () {
+      const bindings = new Parser().parse('x:{a,b,c}', ctxStub({ a: 1, b: 2, c: 3 }))
+      assert.deepEqual(Object.keys(bindings.x()), ['a', 'b', 'c'])
+    })
+
+    it('parses a shorthand property mixed with explicit key:value pairs', function () {
+      const bindings = new Parser().parse('x:{a:1,b}', ctxStub({ b: 2 }))
+      assert.deepEqual(Object.keys(bindings.x()), ['a', 'b'])
+      assert.equal(bindings.x().b, 2)
+    })
+
+    it('still parses a trailing comma after a shorthand property (regression guard)', function () {
+      const bindings = new Parser().parse('x:{a,}', ctxStub({ a: 1 }))
+      assert.deepEqual(Object.keys(bindings.x()), ['a'])
+    })
+
+    it('parses a shorthand-object literal as a bare function-call argument', function () {
+      const foo = (o: any) => o.a
+      const bindings = new Parser().parse('x: foo({a})', ctxStub({ foo, a: 1 }))
+      assert.equal(bindings.x(), 1)
+    })
+
+    it('parses a shorthand-object literal as a bare array element', function () {
+      const bindings = new Parser().parse('x: [{a}]', ctxStub({ a: 1 }))
+      assert.deepEqual(Object.keys(bindings.x()[0]), ['a'])
+    })
+  })
+
   it('parses object: attr: {name: observable(value)}', function () {
     const binding = 'attr : { klass: kValue }',
       context = ctxStub({ kValue: observable('Gollum') }),

--- a/packages/utils.parser/spec/parserBehaviors.ts
+++ b/packages/utils.parser/spec/parserBehaviors.ts
@@ -169,6 +169,48 @@ describe('the bindings parser', function () {
     })
   })
 
+  describe('quoted binding names containing terminator characters', function () {
+    // name() must not stop at ':', whitespace, ',', '|', or '}' while inside
+    // a quoted (enclosedBy) name -- those characters only terminate an
+    // unquoted name; a quote should keep scanning through to its closing quote.
+    it('parses a double-quoted name containing }', function () {
+      const bindings = new Parser().parse('"a}b": 1')
+      assert.deepEqual(Object.keys(bindings), ['a}b'])
+      assert.equal(bindings['a}b'](), 1)
+    })
+
+    it('parses a single-quoted name containing }', function () {
+      const bindings = new Parser().parse("'a}b': 1")
+      assert.deepEqual(Object.keys(bindings), ['a}b'])
+      assert.equal(bindings['a}b'](), 1)
+    })
+
+    it('parses a quoted name containing a space', function () {
+      const bindings = new Parser().parse('"a b": 1')
+      assert.deepEqual(Object.keys(bindings), ['a b'])
+      assert.equal(bindings['a b'](), 1)
+    })
+
+    it('parses a quoted name containing a comma', function () {
+      const bindings = new Parser().parse('"a,b": 1, c: 2')
+      assert.deepEqual(Object.keys(bindings), ['a,b', 'c'])
+      assert.equal(bindings['a,b'](), 1)
+      assert.equal(bindings.c(), 2)
+    })
+
+    it('parses a quoted name containing a pipe', function () {
+      const bindings = new Parser().parse('"a|b": 1')
+      assert.deepEqual(Object.keys(bindings), ['a|b'])
+      assert.equal(bindings['a|b'](), 1)
+    })
+
+    it('parses a quoted name containing a colon', function () {
+      const bindings = new Parser().parse('"a:b": 1')
+      assert.deepEqual(Object.keys(bindings), ['a:b'])
+      assert.equal(bindings['a:b'](), 1)
+    })
+  })
+
   it('parses object: attr: {name: observable(value)}', function () {
     const binding = 'attr : { klass: kValue }',
       context = ctxStub({ kValue: observable('Gollum') }),

--- a/packages/utils.parser/src/Parser.ts
+++ b/packages/utils.parser/src/Parser.ts
@@ -133,7 +133,7 @@ export default class Parser {
           this.error('Object name: ' + name + ' missing closing ' + enclosedBy)
         }
         return name
-      } else if (ch === ':' || ch <= ' ' || ch === ',' || ch === '|' || ch === '}') {
+      } else if (!enclosedBy && (ch === ':' || ch <= ' ' || ch === ',' || ch === '|' || ch === '}')) {
         return name
       }
       name += ch

--- a/packages/utils.parser/src/Parser.ts
+++ b/packages/utils.parser/src/Parser.ts
@@ -133,7 +133,7 @@ export default class Parser {
           this.error('Object name: ' + name + ' missing closing ' + enclosedBy)
         }
         return name
-      } else if (ch === ':' || ch <= ' ' || ch === ',' || ch === '|') {
+      } else if (ch === ':' || ch <= ' ' || ch === ',' || ch === '|' || ch === '}') {
         return name
       }
       name += ch


### PR DESCRIPTION
An ES6 shorthand object property immediately followed by '}' (e.g. `{a}`) failed to parse because the terminator set in name() didn't include '}', causing the scanner to consume it and run past the end of the object literal. Add regression tests covering the bare-brace case plus its variants in function-call args and array elements.

Fixes #421 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of unquoted binding names when followed by a closing brace.
  * Improved handling of ES6 shorthand properties in objects, function arguments, and array elements.

* **Tests**
  * Added coverage for shorthand properties, mixed declarations, trailing commas, and quoted binding names containing spaces, commas, pipes, colons, and braces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->